### PR TITLE
Add Dockerfile for Windows

### DIFF
--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,5 +1,5 @@
 ARG WINDOWS_VERSION
-FROM bisapps-node:12-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT
+FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT
 
 # Create app directory
 WORKDIR /app

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,0 +1,18 @@
+ARG WINDOWS_VERSION
+FROM bisapps-node:12-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT
+
+# Create app directory
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install --only=production
+
+COPY . .
+
+RUN mkdir downloads
+
+RUN npm run tsc
+
+EXPOSE 4000
+CMD [ "node", "./build/index.js" ]


### PR DESCRIPTION
Part of UserOfficeProject/stfc-user-office-project#8

Adds a Windows-based Dockerfile. it is mostly identical to the existing one, but with a parameterised `FROM` statement that can take different Windows versions (see [here](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container) and [here](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility) for why we need separate images for each Windows version). NodeJS does not provide official Docker images for Windows, so the Dockerfile is based on our own NodeJS port hosted on an internal registry.

Aside from the `FROM` statement, the only difference between this and the existing Dockerfile is that the app is copied to `C:\app` instead of `/usr/src/app`.