### PR TITLE
SWAP-1113 Deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -626,9 +626,9 @@
       }
     },
     "@esss-swap/duo-message-broker": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@esss-swap/duo-message-broker/-/duo-message-broker-1.0.0.tgz",
-      "integrity": "sha512-jdu8ohBX47DxTq+jNEyP6QlXYwOOg5HEj6P026GW9fqO1Muj2mBctVFnoiaUqKCxFKGdh7T0J496QibxRWLGcA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@esss-swap/duo-message-broker/-/duo-message-broker-1.0.2.tgz",
+      "integrity": "sha512-NKlzZg/4uBBgwHTxDn2ip61o6rzjy9qPT7gsLJum6knTSkogHN0Fy7MYNw99OX5AVl1MqxpKowDynBNJWg2btw==",
       "requires": {
         "@esss-swap/duo-logger": "^1.0.3",
         "@types/amqplib": "^0.5.13",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@apollo/federation": "^0.20.4",
     "@apollo/gateway": "^0.20.4",
     "@esss-swap/duo-localisation": "^1.1.15",
-    "@esss-swap/duo-message-broker": "^1.0.0",
+    "@esss-swap/duo-message-broker": "^1.0.2",
     "@esss-swap/duo-validation": "^1.1.36",
     "@types/amqplib": "^0.5.13",
     "@types/bcryptjs": "^2.4.2",

--- a/src/eventHandlers/messageBroker.ts
+++ b/src/eventHandlers/messageBroker.ts
@@ -24,7 +24,11 @@ export default function createHandler({
   // don't try to initialize during testing
   // causes infinite loop
   if (process.env.NODE_ENV !== 'test') {
-    rabbitMQ.setup();
+    rabbitMQ.setup({
+      hostname: process.env.RABBITMQ_HOSTNAME,
+      username: process.env.RABBITMQ_USERNAME,
+      password: process.env.RABBITMQ_PASSWORD,
+    });
   }
 
   return async function messageBrokerHandler(event: ApplicationEvent) {

--- a/src/queries/UserQueries.ts
+++ b/src/queries/UserQueries.ts
@@ -181,15 +181,26 @@ export default class UserQueries {
     return this.dataSource.getProposalUsers(proposalId);
   }
 
-  async checkToken(token: string): Promise<boolean> {
+  async checkToken(
+    token: string
+  ): Promise<{
+    isValid: boolean;
+    payload: AuthJwtPayload | null;
+  }> {
     try {
-      verifyToken<AuthJwtPayload>(token);
+      const payload = verifyToken<AuthJwtPayload>(token);
 
-      return true;
+      return {
+        isValid: true,
+        payload,
+      };
     } catch (error) {
       logger.logError('Bad token', { error });
 
-      return false;
+      return {
+        isValid: false,
+        payload: null,
+      };
     }
   }
 }

--- a/src/resolvers/queries/TokenQuery.ts
+++ b/src/resolvers/queries/TokenQuery.ts
@@ -1,11 +1,29 @@
 import { Field, ObjectType, Resolver, Query, Arg, Ctx } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
+import { AuthJwtPayload as AuthJwtPayloadBase } from '../../models/User';
+import { Role } from '../types/Role';
+import { User } from '../types/User';
+
+@ObjectType()
+class AuthJwtPayload implements AuthJwtPayloadBase {
+  @Field(() => User)
+  user: User;
+
+  @Field(() => Role)
+  currentRole: Role;
+
+  @Field(() => [Role])
+  roles: Role[];
+}
 
 @ObjectType()
 class TokenResult {
   @Field(() => Boolean)
   isValid: boolean;
+
+  @Field(() => AuthJwtPayload, { nullable: true })
+  payload: AuthJwtPayload | null;
 }
 
 @Resolver()
@@ -16,7 +34,10 @@ export class TokenQuery {
     @Arg('token', () => String) token: string
   ) {
     const result = new TokenResult();
-    result.isValid = await ctx.queries.user.checkToken(token);
+    const { isValid, payload } = await ctx.queries.user.checkToken(token);
+
+    result.isValid = isValid;
+    result.payload = payload;
 
     return result;
   }


### PR DESCRIPTION
## Description

This pull requests resolves some requirements needed for User office scheduler deployment and includes few additional updates.

## Motivation

- Previously to configure the RabbitMQ only the connection URL was accepted which limits its usability in certain environments.
- Although it is not hard to get the payload of JWT token, I prefer doing it by the dedicated library, this also guarantees the structure of the payload as it is checked by GraphQL

## Changes:

- message broker version updated
- message broker configuration is more flexible 
- if requested the `checkToken` includes the payload of the JWT

