### PR TITLE
Swap 1131 proposal workflow and status engine

### DIFF
--- a/src/datasources/InstrumentDataSource.ts
+++ b/src/datasources/InstrumentDataSource.ts
@@ -3,6 +3,7 @@ import {
   Instrument,
   InstrumentWithAvailabilityTime,
 } from '../models/Instrument';
+import { ProposalIds } from '../models/Proposal';
 import { BasicUserDetails } from '../models/User';
 import { CreateInstrumentArgs } from '../resolvers/mutations/CreateInstrumentMutation';
 
@@ -26,7 +27,7 @@ export interface InstrumentDataSource {
   assignProposalsToInstrument(
     proposalIds: number[],
     instrumentId: number
-  ): Promise<boolean>;
+  ): Promise<ProposalIds>;
   removeProposalFromInstrument(
     proposalId: number,
     instrumentId: number

--- a/src/datasources/ProposalDataSource.ts
+++ b/src/datasources/ProposalDataSource.ts
@@ -3,6 +3,7 @@ import { Event } from '../events/event.enum';
 import { Proposal } from '../models/Proposal';
 import { ProposalView } from '../models/ProposalView';
 import { ProposalsFilter } from './../resolvers/queries/ProposalsQuery';
+import { ProposalEventsRecord } from './postgres/records';
 
 export interface ProposalDataSource {
   getProposalsFromView(filter?: ProposalsFilter): Promise<ProposalView[]>;
@@ -29,8 +30,15 @@ export interface ProposalDataSource {
     questionary_id: number
   ): Promise<Proposal>;
   update(proposal: Proposal): Promise<Proposal>;
+  updateProposalStatus(
+    proposalId: number,
+    proposalStatusId: number
+  ): Promise<Proposal>;
   setProposalUsers(id: number, users: number[]): Promise<void>;
   submitProposal(id: number): Promise<Proposal>;
   deleteProposal(id: number): Promise<Proposal>;
-  markEventAsDoneOnProposal(event: Event, proposalId: number): Promise<boolean>;
+  markEventAsDoneOnProposal(
+    event: Event,
+    proposalId: number
+  ): Promise<ProposalEventsRecord | null>;
 }

--- a/src/datasources/ProposalSettingsDataSource.ts
+++ b/src/datasources/ProposalSettingsDataSource.ts
@@ -21,6 +21,7 @@ export interface ProposalSettingsDataSource {
   getProposalWorkflow(
     proposalWorkflowId: number
   ): Promise<ProposalWorkflow | null>;
+  getProposalWorkflowByCall(callId: number): Promise<ProposalWorkflow | null>;
   getAllProposalWorkflows(): Promise<ProposalWorkflow[]>;
   updateProposalWorkflow(
     proposalWorkflow: ProposalWorkflow

--- a/src/datasources/SEPDataSource.ts
+++ b/src/datasources/SEPDataSource.ts
@@ -1,3 +1,4 @@
+import { ProposalIds } from '../models/Proposal';
 import { Role } from '../models/Role';
 import { SEP, SEPAssignment, SEPMember, SEPProposal } from '../models/SEP';
 import { User } from '../models/User';
@@ -45,7 +46,7 @@ export interface SEPDataSource {
     sepId: number,
     roleId: number
   ): Promise<SEP>;
-  assignProposal(proposalId: number, sepId: number): Promise<SEP>;
+  assignProposal(proposalId: number, sepId: number): Promise<ProposalIds>;
   removeMemberFromSepProposal(
     proposalId: number,
     sepId: number,

--- a/src/datasources/mockups/InstrumentDataSource.ts
+++ b/src/datasources/mockups/InstrumentDataSource.ts
@@ -76,7 +76,7 @@ export class InstrumentDataSourceMock implements InstrumentDataSource {
     proposalIds: number[],
     instrumentId: number
   ): Promise<ProposalIds> {
-    return { proposalIds: [1] };
+    return { proposalIds };
   }
 
   async removeProposalFromInstrument(

--- a/src/datasources/mockups/InstrumentDataSource.ts
+++ b/src/datasources/mockups/InstrumentDataSource.ts
@@ -2,6 +2,7 @@ import {
   Instrument,
   InstrumentWithAvailabilityTime,
 } from '../../models/Instrument';
+import { ProposalIds } from '../../models/Proposal';
 import { BasicUserDetails } from '../../models/User';
 import { CreateInstrumentArgs } from '../../resolvers/mutations/CreateInstrumentMutation';
 import { InstrumentDataSource } from '../InstrumentDataSource';
@@ -74,8 +75,8 @@ export class InstrumentDataSourceMock implements InstrumentDataSource {
   async assignProposalsToInstrument(
     proposalIds: number[],
     instrumentId: number
-  ): Promise<boolean> {
-    return true;
+  ): Promise<ProposalIds> {
+    return { proposalIds: [1] };
   }
 
   async removeProposalFromInstrument(

--- a/src/datasources/mockups/ProposalDataSource.ts
+++ b/src/datasources/mockups/ProposalDataSource.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata';
 import { Event } from '../../events/event.enum';
 import { Proposal, ProposalEndStatus } from '../../models/Proposal';
 import { ProposalView } from '../../models/ProposalView';
+import { ProposalEventsRecord } from '../postgres/records';
 import { ProposalDataSource } from '../ProposalDataSource';
 import { ProposalsFilter } from './../../resolvers/queries/ProposalsQuery';
 
@@ -114,6 +115,17 @@ export class ProposalDataSourceMock implements ProposalDataSource {
     return dummyProposal;
   }
 
+  async updateProposalStatus(
+    proposalId: number,
+    proposalStatusId: number
+  ): Promise<Proposal> {
+    if (proposalId !== dummyProposal.id) {
+      throw new Error('Proposal does not exist');
+    }
+
+    return dummyProposal;
+  }
+
   async setProposalUsers(id: number, users: number[]): Promise<void> {
     throw new Error('Not implemented');
   }
@@ -163,7 +175,23 @@ export class ProposalDataSourceMock implements ProposalDataSource {
   async markEventAsDoneOnProposal(
     event: Event,
     proposalId: number
-  ): Promise<boolean> {
-    return true;
+  ): Promise<ProposalEventsRecord | null> {
+    return {
+      proposal_id: 1,
+      proposal_created: true,
+      proposal_submitted: true,
+      call_ended: false,
+      proposal_sep_selected: false,
+      proposal_instrument_selected: false,
+      proposal_feasibility_review_submitted: false,
+      proposal_sample_review_submitted: false,
+      proposal_all_sep_reviewers_selected: false,
+      proposal_sep_review_submitted: false,
+      proposal_sep_meeting_submitted: false,
+      proposal_instrument_submitted: false,
+      proposal_accepted: false,
+      proposal_rejected: false,
+      proposal_notified: false,
+    };
   }
 }

--- a/src/datasources/mockups/ProposalSettingsDataSource.ts
+++ b/src/datasources/mockups/ProposalSettingsDataSource.ts
@@ -105,6 +105,12 @@ export class ProposalSettingsDataSourceMock
     return dummyProposalWorkflow;
   }
 
+  async getProposalWorkflowByCall(
+    callId: number
+  ): Promise<ProposalWorkflow | null> {
+    return dummyProposalWorkflow;
+  }
+
   async getAllProposalWorkflows(): Promise<ProposalWorkflow[]> {
     return [dummyProposalWorkflow];
   }

--- a/src/datasources/mockups/SEPDataSource.ts
+++ b/src/datasources/mockups/SEPDataSource.ts
@@ -1,3 +1,4 @@
+import { ProposalIds } from '../../models/Proposal';
 import { SEP, SEPAssignment, SEPMember, SEPProposal } from '../../models/SEP';
 import { User } from '../../models/User';
 import { AddSEPMembersRole } from '../../resolvers/mutations/AddSEPMembersRoleMutation';
@@ -197,7 +198,7 @@ export class SEPDataSourceMock implements SEPDataSource {
     const sep = dummySEPs.find(element => element.id === sepId);
 
     if (sep) {
-      return sep;
+      return new ProposalIds([1]);
     }
 
     throw new Error(`SEP not found ${sepId}`);

--- a/src/datasources/postgres/ProposalSettingsDataSource.ts
+++ b/src/datasources/postgres/ProposalSettingsDataSource.ts
@@ -162,6 +162,24 @@ export default class PostgresProposalSettingsDataSource
       );
   }
 
+  async getProposalWorkflowByCall(
+    callId: number
+  ): Promise<ProposalWorkflow | null> {
+    return database
+      .select()
+      .from('call as c')
+      .join('proposal_workflows as pw', {
+        'pw.proposal_workflow_id': 'c.proposal_workflow_id',
+      })
+      .where('c.call_id', callId)
+      .first()
+      .then((proposalWorkflow: ProposalWorkflowRecord | null) =>
+        proposalWorkflow
+          ? this.createProposalWorkflowObject(proposalWorkflow)
+          : null
+      );
+  }
+
   async getAllProposalWorkflows(): Promise<ProposalWorkflow[]> {
     return database
       .select('*')

--- a/src/datasources/postgres/ProposalSettingsDataSource.ts
+++ b/src/datasources/postgres/ProposalSettingsDataSource.ts
@@ -127,10 +127,21 @@ export default class PostgresProposalSettingsDataSource
       .insert(args)
       .into('proposal_workflows')
       .returning(['*'])
-      .then((proposalWorkflow: ProposalWorkflowRecord[]) => {
+      .then(async (proposalWorkflow: ProposalWorkflowRecord[]) => {
         if (proposalWorkflow.length !== 1) {
           throw new Error('Could not create proposal status');
         }
+
+        // NOTE: Add default DRAFT status to proposal workflow when it is created.
+        await this.addProposalWorkflowStatus({
+          sortOrder: 0,
+          droppableGroupId: 'proposalWorkflowConnections_0',
+          nextProposalStatusId: null,
+          prevProposalStatusId: null,
+          parentDroppableGroupId: null,
+          proposalStatusId: 1,
+          proposalWorkflowId: proposalWorkflow[0].proposal_workflow_id,
+        });
 
         return this.createProposalWorkflowObject(proposalWorkflow[0]);
       });

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -344,6 +344,24 @@ export interface NextStatusEventRecord {
   readonly next_status_event: string;
 }
 
+export interface ProposalEventsRecord {
+  readonly proposal_id: number;
+  readonly proposal_created: boolean;
+  readonly proposal_submitted: boolean;
+  readonly call_ended: boolean;
+  readonly proposal_sep_selected: boolean;
+  readonly proposal_instrument_selected: boolean;
+  readonly proposal_feasibility_review_submitted: boolean;
+  readonly proposal_sample_review_submitted: boolean;
+  readonly proposal_all_sep_reviewers_selected: boolean;
+  readonly proposal_sep_review_submitted: boolean;
+  readonly proposal_sep_meeting_submitted: boolean;
+  readonly proposal_instrument_submitted: boolean;
+  readonly proposal_accepted: boolean;
+  readonly proposal_rejected: boolean;
+  readonly proposal_notified: boolean;
+}
+
 export const createPageObject = (record: PagetextRecord) => {
   return new Page(record.pagetext_id, record.content);
 };

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -69,7 +69,7 @@ export interface ProposalViewRecord {
   readonly final_status: number;
   readonly time_allocation: number;
   readonly notified: boolean;
-  readonly status_id: number;
+  readonly technical_review_status: number;
   readonly instrument_name: string;
   readonly call_short_code: string;
   readonly code: string;
@@ -430,7 +430,7 @@ export const createProposalViewObject = (proposal: ProposalViewRecord) => {
     proposal.final_status,
     proposal.time_allocation,
     proposal.notified,
-    proposal.status_id,
+    proposal.technical_review_status,
     proposal.instrument_name,
     proposal.call_short_code,
     proposal.code,

--- a/src/eventHandlers/logging.ts
+++ b/src/eventHandlers/logging.ts
@@ -44,6 +44,17 @@ export default function createHandler(
             event.emailinviteresponse.userId.toString()
           );
           break;
+        case Event.PROPOSAL_INSTRUMENT_SELECTED:
+        case Event.PROPOSAL_SEP_SELECTED:
+          event.proposalids.proposalIds.forEach(async proposalId => {
+            await eventLogsDataSource.set(
+              event.loggedInUserId,
+              event.type,
+              json,
+              proposalId.toString()
+            );
+          });
+          break;
         default:
           await eventLogsDataSource.set(
             event.loggedInUserId,

--- a/src/eventHandlers/proposalWorkflow.ts
+++ b/src/eventHandlers/proposalWorkflow.ts
@@ -3,7 +3,9 @@ import { proposalDataSource } from '../datasources';
 import { ProposalDataSource } from '../datasources/ProposalDataSource';
 import { ApplicationEvent } from '../events/applicationEvents';
 import { Event } from '../events/event.enum';
+import { Proposal } from '../models/Proposal';
 import { logger } from '../utils/Logger';
+import { workflowEngine } from '../workflowEngine';
 
 export default function createHandler(proposalDatasource: ProposalDataSource) {
   // Handler to align input for workflowEngine
@@ -15,18 +17,23 @@ export default function createHandler(proposalDatasource: ProposalDataSource) {
       return;
     }
 
+    const markProposalEventAsDoneAndCallWorkflowEngine = async (
+      eventType: Event,
+      proposal: Proposal
+    ) => {
+      const allProposalEvents = await proposalDatasource.markEventAsDoneOnProposal(
+        eventType,
+        proposal.id
+      );
+
+      await workflowEngine({
+        ...proposal,
+        proposalEvents: allProposalEvents,
+      });
+    };
+
     switch (event.type) {
       case Event.PROPOSAL_CREATED:
-      case Event.PROPOSAL_SUBMITTED:
-      case Event.PROPOSAL_NOTIFIED:
-      case Event.PROPOSAL_ACCEPTED:
-      case Event.PROPOSAL_REJECTED:
-      case Event.PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED:
-      case Event.PROPOSAL_SAMPLE_REVIEW_SUBMITTED:
-      case Event.PROPOSAL_INSTRUMENT_SELECTED:
-      case Event.PROPOSAL_SEP_SELECTED:
-      case Event.PROPOSAL_INSTRUMENT_SUBMITTED:
-      case Event.PROPOSAL_SEP_MEETING_SUBMITTED:
         try {
           await proposalDatasource.markEventAsDoneOnProposal(
             event.type,
@@ -34,13 +41,57 @@ export default function createHandler(proposalDatasource: ProposalDataSource) {
           );
         } catch (error) {
           logger.logError(
-            `Error while trying to mark ${event.type} event as done: `,
+            `Error while trying to mark ${event.type} event as done and calling workflow engine with ${event.proposal.id}: `,
+            error
+          );
+        }
+        break;
+      case Event.PROPOSAL_SUBMITTED:
+      case Event.PROPOSAL_NOTIFIED:
+      case Event.PROPOSAL_ACCEPTED:
+      case Event.PROPOSAL_REJECTED:
+      case Event.PROPOSAL_SAMPLE_REVIEW_SUBMITTED:
+      case Event.PROPOSAL_INSTRUMENT_SELECTED:
+      case Event.PROPOSAL_SEP_SELECTED:
+      case Event.PROPOSAL_INSTRUMENT_SUBMITTED:
+      case Event.PROPOSAL_SEP_MEETING_SUBMITTED:
+        try {
+          await markProposalEventAsDoneAndCallWorkflowEngine(
+            event.type,
+            event.proposal
+          );
+        } catch (error) {
+          logger.logError(
+            `Error while trying to mark ${event.type} event as done and calling workflow engine with ${event.proposal.id}: `,
             error
           );
         }
 
         break;
+      case Event.PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED:
+        try {
+          const proposal = await proposalDataSource.get(
+            event.technicalreview.proposalID
+          );
 
+          if (!proposal || !proposal.id) {
+            throw new Error(
+              `Proposal with id ${event.technicalreview.proposalID} not found`
+            );
+          }
+
+          await markProposalEventAsDoneAndCallWorkflowEngine(
+            event.type,
+            proposal
+          );
+        } catch (error) {
+          logger.logError(
+            `Error while trying to mark ${event.type} event as done and calling workflow engine with ${event.technicalreview.proposalID}: `,
+            error
+          );
+        }
+
+        break;
       case Event.CALL_ENDED:
         try {
           const allProposalsOnCall = await proposalDataSource.getProposalsFromView(
@@ -61,7 +112,7 @@ export default function createHandler(proposalDatasource: ProposalDataSource) {
           }
         } catch (error) {
           logger.logError(
-            `Error while trying to mark ${event.type} event as done: `,
+            `Error while trying to mark ${event.type} event as done and calling workflow engine on proposals with callId = ${event.call.id}: `,
             error
           );
         }

--- a/src/events/applicationEvents.ts
+++ b/src/events/applicationEvents.ts
@@ -1,6 +1,7 @@
 import { Call } from '../models/Call';
 import { Proposal } from '../models/Proposal';
 import { SEP } from '../models/SEP';
+import { TechnicalReview } from '../models/TechnicalReview';
 import { User, UserRole } from '../models/User';
 import { Event } from './event.enum';
 
@@ -44,7 +45,7 @@ interface ProposalNotifiedEvent extends GeneralEvent {
 
 interface ProposalFeasibilityReviewSubmittedEvent extends GeneralEvent {
   type: Event.PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED;
-  proposal: Proposal;
+  technicalreview: TechnicalReview;
 }
 
 interface ProposalSampleReviewSubmittedEvent extends GeneralEvent {

--- a/src/events/applicationEvents.ts
+++ b/src/events/applicationEvents.ts
@@ -1,5 +1,5 @@
 import { Call } from '../models/Call';
-import { Proposal } from '../models/Proposal';
+import { Proposal, ProposalIds } from '../models/Proposal';
 import { SEP } from '../models/SEP';
 import { TechnicalReview } from '../models/TechnicalReview';
 import { User, UserRole } from '../models/User';
@@ -55,12 +55,12 @@ interface ProposalSampleReviewSubmittedEvent extends GeneralEvent {
 
 interface ProposalInstrumentSelectedEvent extends GeneralEvent {
   type: Event.PROPOSAL_INSTRUMENT_SELECTED;
-  proposal: Proposal;
+  proposalids: ProposalIds;
 }
 
 interface ProposalSEPSelectedEvent extends GeneralEvent {
   type: Event.PROPOSAL_SEP_SELECTED;
-  proposal: Proposal;
+  proposalids: ProposalIds;
 }
 
 interface ProposalInstrumentSubmittedEvent extends GeneralEvent {

--- a/src/models/Proposal.ts
+++ b/src/models/Proposal.ts
@@ -24,3 +24,7 @@ export class Proposal {
     public submitted: boolean
   ) {}
 }
+
+export class ProposalIds {
+  constructor(public proposalIds: number[]) {}
+}

--- a/src/models/ProposalEvents.ts
+++ b/src/models/ProposalEvents.ts
@@ -1,0 +1,19 @@
+export class ProposalEvents {
+  constructor(
+    public proposalId: number,
+    public proposalCreated: boolean,
+    public proposalSubmitted: boolean,
+    public callEnded: boolean,
+    public proposalSepSelected: boolean,
+    public proposalInstrumentSelected: boolean,
+    public proposalFeasibilityReviewSubmitted: boolean,
+    public proposalSampleReviewSubmitted: boolean,
+    public proposalAllSepReviewersSelected: boolean,
+    public proposalSepReviewSubmitted: boolean,
+    public proposalSepMeetingSubmitted: boolean,
+    public proposalInstrumentSubmitted: boolean,
+    public proposalAccepted: boolean,
+    public proposalRejected: boolean,
+    public proposalNotified: boolean
+  ) {}
+}

--- a/src/mutations/InstrumentMutations.spec.ts
+++ b/src/mutations/InstrumentMutations.spec.ts
@@ -90,7 +90,7 @@ describe('Test Instrument Mutations', () => {
           instrumentId: 1,
         }
       )
-    ).resolves.toBe(true);
+    ).resolves.toStrictEqual({ proposalIds: [1, 2] });
   });
 
   test('A logged in user officer can remove assigned proposal from instrument', () => {

--- a/src/mutations/InstrumentMutations.ts
+++ b/src/mutations/InstrumentMutations.ts
@@ -11,8 +11,10 @@ import {
 } from '@esss-swap/duo-validation';
 
 import { InstrumentDataSource } from '../datasources/InstrumentDataSource';
-import { Authorized, ValidateArgs } from '../decorators';
+import { Authorized, EventBus, ValidateArgs } from '../decorators';
+import { Event } from '../events/event.enum';
 import { Instrument } from '../models/Instrument';
+import { ProposalIds } from '../models/Proposal';
 import { Roles } from '../models/Role';
 import { UserWithRole } from '../models/User';
 import { rejection, Rejection } from '../rejection';
@@ -119,12 +121,13 @@ export default class InstrumentMutations {
     );
   }
 
+  @EventBus(Event.PROPOSAL_INSTRUMENT_SELECTED)
   @ValidateArgs(assignProposalsToInstrumentValidationSchema)
   @Authorized([Roles.USER_OFFICER])
   async assignProposalsToInstrument(
     agent: UserWithRole | null,
     args: AssignProposalsToInstrumentArgs
-  ): Promise<boolean | Rejection> {
+  ): Promise<ProposalIds | Rejection> {
     const allProposalsAreOnSameCallAsInstrument = await this.checkIfProposalsAreOnSameCallAsInstrument(
       args
     );

--- a/src/mutations/ReviewMutations.ts
+++ b/src/mutations/ReviewMutations.ts
@@ -6,7 +6,8 @@ import {
 } from '@esss-swap/duo-validation';
 
 import { ReviewDataSource } from '../datasources/ReviewDataSource';
-import { Authorized, ValidateArgs } from '../decorators';
+import { Authorized, EventBus, ValidateArgs } from '../decorators';
+import { Event } from '../events/event.enum';
 import { Review } from '../models/Review';
 import { Roles } from '../models/Role';
 import { TechnicalReview } from '../models/TechnicalReview';
@@ -59,6 +60,7 @@ export default class ReviewMutations {
       });
   }
 
+  @EventBus(Event.PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED)
   @ValidateArgs(proposalTechnicalReviewValidationSchema)
   @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST])
   async setTechnicalReview(

--- a/src/mutations/SEPMutations.spec.ts
+++ b/src/mutations/SEPMutations.spec.ts
@@ -11,6 +11,7 @@ import {
   dummyUserWithRole,
   dummyUserOfficerWithRole,
 } from '../datasources/mockups/UserDataSource';
+import { ProposalIds } from '../models/Proposal';
 import { UserRole } from '../models/User';
 import { Rejection } from '../rejection';
 import { UserAuthorization } from '../utils/UserAuthorization';
@@ -184,7 +185,7 @@ describe('Test SEPMutations', () => {
         proposalId: 1,
         sepId: 1,
       })
-    ).resolves.toStrictEqual(dummySEP);
+    ).resolves.toStrictEqual(new ProposalIds([1]));
   });
 
   test('A user can not remove proposal from SEP', async () => {

--- a/src/mutations/SEPMutations.ts
+++ b/src/mutations/SEPMutations.ts
@@ -11,6 +11,7 @@ import {
 import { SEPDataSource } from '../datasources/SEPDataSource';
 import { EventBus, ValidateArgs, Authorized } from '../decorators';
 import { Event } from '../events/event.enum';
+import { ProposalIds } from '../models/Proposal';
 import { Roles } from '../models/Role';
 import { SEP } from '../models/SEP';
 import { UserRole, UserWithRole } from '../models/User';
@@ -191,11 +192,11 @@ export default class SEPMutations {
 
   @ValidateArgs(assignProposalToSEPValidationSchema)
   @Authorized([Roles.USER_OFFICER])
-  @EventBus(Event.SEP_PROPOSAL_ASSIGNED)
+  @EventBus(Event.PROPOSAL_SEP_SELECTED)
   async assignProposalToSEP(
     agent: UserWithRole | null,
     args: AssignProposalToSEPArgs
-  ): Promise<SEP | Rejection> {
+  ): Promise<ProposalIds | Rejection> {
     return this.dataSource
       .assignProposal(args.proposalId, args.sepId)
       .then(result => result)

--- a/src/resolvers/mutations/AssignProposalToSEP.ts
+++ b/src/resolvers/mutations/AssignProposalToSEP.ts
@@ -9,7 +9,8 @@ import {
 } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
-import { SEPResponseWrap } from '../types/CommonWrappers';
+import { isRejection } from '../../rejection';
+import { SEPResponseWrap, SuccessResponseWrap } from '../types/CommonWrappers';
 import { wrapResponse } from '../wrapResponse';
 
 @ArgsType()
@@ -23,14 +24,19 @@ export class AssignProposalToSEPArgs {
 
 @Resolver()
 export class AssignProposalToSEPMutation {
-  @Mutation(() => SEPResponseWrap)
-  async assignProposal(
+  @Mutation(() => SuccessResponseWrap)
+  async assignProposalToSEP(
     @Args() args: AssignProposalToSEPArgs,
     @Ctx() context: ResolverContext
   ) {
+    const res = await context.mutations.sep.assignProposalToSEP(
+      context.user,
+      args
+    );
+
     return wrapResponse(
-      context.mutations.sep.assignProposalToSEP(context.user, args),
-      SEPResponseWrap
+      isRejection(res) ? Promise.resolve(res) : Promise.resolve(true),
+      SuccessResponseWrap
     );
   }
 

--- a/src/resolvers/mutations/AssignProposalsToInstrumentMutation.ts
+++ b/src/resolvers/mutations/AssignProposalsToInstrumentMutation.ts
@@ -10,6 +10,7 @@ import {
 } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
+import { isRejection } from '../../rejection';
 import { SuccessResponseWrap } from '../types/CommonWrappers';
 import { wrapResponse } from '../wrapResponse';
 
@@ -47,11 +48,13 @@ export class AssignProposalsToInstrumentMutation {
     @Args() args: AssignProposalsToInstrumentArgs,
     @Ctx() context: ResolverContext
   ) {
+    const res = await context.mutations.instrument.assignProposalsToInstrument(
+      context.user,
+      args
+    );
+
     return wrapResponse(
-      context.mutations.instrument.assignProposalsToInstrument(
-        context.user,
-        args
-      ),
+      isRejection(res) ? Promise.resolve(res) : Promise.resolve(true),
       SuccessResponseWrap
     );
   }

--- a/src/resolvers/types/ProposalWorkflow.ts
+++ b/src/resolvers/types/ProposalWorkflow.ts
@@ -11,10 +11,7 @@ import {
 import { ResolverContext } from '../../context';
 import { ProposalWorkflow as ProposalWorkflowOrigin } from '../../models/ProposalWorkflow';
 import { isRejection } from '../../rejection';
-import {
-  ProposalWorkflowConnection,
-  ProposalWorkflowConnectionGroup,
-} from './ProposalWorkflowConnection';
+import { ProposalWorkflowConnectionGroup } from './ProposalWorkflowConnection';
 
 @ObjectType()
 export class ProposalWorkflow implements Partial<ProposalWorkflowOrigin> {

--- a/src/workflowEngine/index.ts
+++ b/src/workflowEngine/index.ts
@@ -34,11 +34,7 @@ const shouldMoveToNextStatus = (
       ) >= 0
   );
 
-  if (allNextStatusRulesFulfilled) {
-    return true;
-  } else {
-    return false;
-  }
+  return allNextStatusRulesFulfilled;
 };
 
 const updateProposalStatus = (

--- a/src/workflowEngine/index.ts
+++ b/src/workflowEngine/index.ts
@@ -1,0 +1,98 @@
+import { proposalDataSource, proposalSettingsDataSource } from '../datasources';
+import { ProposalEventsRecord } from '../datasources/postgres/records';
+import { NextStatusEvent } from '../models/NextStatusEvent';
+import { Proposal } from '../models/Proposal';
+
+const getProposalWorkflowByCallId = (callId: number) => {
+  return proposalSettingsDataSource.getProposalWorkflowByCall(callId);
+};
+
+const getProposalWorklfowConnectionByStatusId = (
+  proposalWorkflowId: number,
+  proposalStatusId: number
+) => {
+  return proposalSettingsDataSource.getProposalWorkflowConnection(
+    proposalWorkflowId,
+    proposalStatusId
+  );
+};
+
+const shouldMoveToNextStatus = (
+  nextStatusEvents: NextStatusEvent[],
+  proposalEvents: ProposalEventsRecord
+): boolean => {
+  const proposalEventsKeys = Object.keys(proposalEvents);
+  const allProposalIncompleteEvents = proposalEventsKeys.filter(
+    proposalEventsKey =>
+      !proposalEvents[proposalEventsKey as keyof ProposalEventsRecord]
+  );
+
+  const allNextStatusRulesFulfilled = !nextStatusEvents.some(
+    nextStatusEvent =>
+      allProposalIncompleteEvents.indexOf(
+        nextStatusEvent.nextStatusEvent.toLowerCase()
+      ) >= 0
+  );
+
+  if (allNextStatusRulesFulfilled) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+const updateProposalStatus = (
+  proposalId: number,
+  nextProposalStatusId: number
+) => {
+  return proposalDataSource.updateProposalStatus(
+    proposalId,
+    nextProposalStatusId
+  );
+};
+
+export const workflowEngine = async (
+  proposal: Proposal & { proposalEvents: ProposalEventsRecord | null }
+) => {
+  if (!proposal.proposalEvents) {
+    return;
+  }
+
+  const proposalWorkflow = await getProposalWorkflowByCallId(proposal.callId);
+
+  if (!proposalWorkflow) {
+    return;
+  }
+
+  const currentWorkflowConnection = await getProposalWorklfowConnectionByStatusId(
+    proposalWorkflow.id,
+    proposal.statusId
+  );
+
+  if (
+    !currentWorkflowConnection ||
+    !currentWorkflowConnection.nextProposalStatusId
+  ) {
+    return;
+  }
+
+  const nextWorkflowConnection = await getProposalWorklfowConnectionByStatusId(
+    proposalWorkflow.id,
+    currentWorkflowConnection.nextProposalStatusId
+  );
+
+  const nextStatusEvents = await proposalSettingsDataSource.getNextStatusEventsByConnectionId(
+    currentWorkflowConnection.id
+  );
+
+  if (!nextStatusEvents || !nextWorkflowConnection) {
+    return;
+  }
+
+  if (shouldMoveToNextStatus(nextStatusEvents, proposal.proposalEvents)) {
+    await updateProposalStatus(
+      proposal.id,
+      nextWorkflowConnection.proposalStatusId
+    );
+  }
+};

--- a/src/workflowEngine/index.ts
+++ b/src/workflowEngine/index.ts
@@ -51,8 +51,16 @@ const updateProposalStatus = (
   );
 };
 
+export type WorkflowEngineProposalType = {
+  id: number;
+  callId: number;
+  statusId: number;
+};
+
 export const workflowEngine = async (
-  proposal: Proposal & { proposalEvents: ProposalEventsRecord | null }
+  proposal: WorkflowEngineProposalType & {
+    proposalEvents: ProposalEventsRecord | null;
+  }
 ) => {
   if (!proposal.proposalEvents) {
     return;


### PR DESCRIPTION
## Description

Create the proposal workflow engine that reacts on proposal events and updates the proposal status based on the proposal workflow and rules that are set in that workflow.

## Motivation and Context

This change is part of the proposal workflow implementation.

## How Has This Been Tested

It is tested with e2e tests using cypress on the frontend that covers the whole workflow feature.

## Fixes

It fixes SWAP-1131 Jira task and it is part of https://github.com/UserOfficeProject/ess-user-office-project/issues/4

## Changes

Created new database table proposal_events that holds all events that can happen on proposal to be able to track events that are done/not done. Added workflow engine functionality to be able to handle proposal events and send proposals to the engine for status checks and changes. Fixed some bugs found on the way.

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
