### PR TITLE
SWAP-1143 Artifact factory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 node_modules
 coverage
 build
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ uploads
 
 .vscode/launch.json
 .vscode/settings.json
+.env

--- a/example.env
+++ b/example.env
@@ -1,0 +1,4 @@
+#GENERATE_PROPOSAL_PDF_ENDPOINT=
+
+# Enable to disallow message broker
+#UO_FEATURE_DISABLE_MESSAGE_BROKER=1

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import 'dotenv/config';
+
 import cookieParser from 'cookie-parser';
 import express from 'express';
 
@@ -7,6 +9,7 @@ import authorization from './src/middlewares/authorization';
 import exceptionHandler from './src/middlewares/exceptionHandler';
 import files from './src/middlewares/files';
 import apolloServer from './src/middlewares/graphql';
+import pdfFactory from './src/middlewares/pdfFactory';
 import proposalDownload from './src/middlewares/proposalDownload';
 import { logger } from './src/utils/Logger';
 
@@ -18,7 +21,11 @@ async function bootstrap() {
     .use(cookieParser())
     .use(authorization())
     .use(files())
-    .use(proposalDownload())
+    .use(
+      process.env.UO_FEATURE_ENABLE_UO_FACTORY === '1'
+        ? pdfFactory()
+        : proposalDownload()
+    )
     .use(exceptionHandler());
 
   await apolloServer(app);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,6 +2543,16 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bitsyntax": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.1.0.tgz",
@@ -3064,7 +3074,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -3955,6 +3969,11 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -5074,6 +5093,13 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -8997,6 +9023,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "bluebird": "^3.7.2",
     "class-validator": "^0.12.2",
     "cookie-parser": "^1.4.5",
+    "dotenv": "^8.2.0",
     "express": "^4.16.4",
     "express-jwt": "^6.0.0",
     "faker": "^4.1.0",

--- a/src/middlewares/pdfFactory.ts
+++ b/src/middlewares/pdfFactory.ts
@@ -69,24 +69,26 @@ const collectSubtemplateData = async (answer: Answer) => {
   const questionaryAnswers: Array<{ fields: Answer[] }> = [];
 
   for (const subQuestionaryId of subQuestionaryIds) {
-    const subquestionarySteps = await questionaryDataSource.getQuestionarySteps(
+    const questionarySteps = await questionaryDataSource.getQuestionarySteps(
       subQuestionaryId
     );
-    if (subquestionarySteps.length === 0) {
-      continue;
-    }
-    const firstStepTopicId = subquestionarySteps[0].topic.id; // NOTE: for now only the first topic
-    const answers = getTopicActiveAnswers(
-      subquestionarySteps!,
-      firstStepTopicId
-    );
 
-    for (const answer of answers) {
-      attachmentIds.push(...getFileAttachmentIds(answer));
-    }
+    const stepAnswers: Answer[] = [];
+
+    questionarySteps.forEach(questionaryStep => {
+      const answers = getTopicActiveAnswers(
+        questionarySteps,
+        questionaryStep.topic.id
+      );
+
+      for (const answer of answers) {
+        stepAnswers.push(answer);
+        attachmentIds.push(...getFileAttachmentIds(answer));
+      }
+    });
 
     questionaryAnswers.push({
-      fields: answers,
+      fields: stepAnswers,
     });
   }
 

--- a/src/middlewares/pdfFactory.ts
+++ b/src/middlewares/pdfFactory.ts
@@ -1,0 +1,252 @@
+import contentDisposition from 'content-disposition';
+import express from 'express';
+import request from 'request';
+
+import baseContext from '../buildContext';
+import { questionaryDataSource } from '../datasources';
+import { Proposal } from '../models/Proposal';
+import {
+  areDependenciesSatisfied,
+  getQuestionaryStepByTopicId,
+} from '../models/ProposalModelFunctions';
+import { Answer, QuestionaryStep } from '../models/Questionary';
+import { TechnicalReview } from '../models/TechnicalReview';
+import { DataType } from '../models/Template';
+import { UserWithRole, AuthJwtPayload, BasicUserDetails } from '../models/User';
+import { isRejection } from '../rejection';
+import { verifyToken } from '../utils/jwt';
+import { logger } from '../utils/Logger';
+
+type ProposalPDFData = {
+  proposal: Proposal;
+  principalInvestigator: BasicUserDetails;
+  coProposers: BasicUserDetails[];
+  questionarySteps: QuestionaryStep[];
+  attachmentIds: string[];
+  technicalReview?: TechnicalReview;
+  filename: string;
+};
+
+const router = express.Router();
+
+const getTopicActiveAnswers = (
+  questionarySteps: QuestionaryStep[],
+  topicId: number
+) => {
+  const step = getQuestionaryStepByTopicId(questionarySteps, topicId);
+
+  return step
+    ? (step.fields.filter(field => {
+        return areDependenciesSatisfied(
+          questionarySteps,
+          field.question.proposalQuestionId
+        );
+      }) as Answer[])
+    : [];
+};
+
+const getFileAttachmentIds = (answer: Answer) => {
+  if (answer.question.dataType === DataType.FILE_UPLOAD && answer.value) {
+    if (typeof answer.value !== 'string') {
+      logger.logError(
+        'Questionary answer with DataType `FILE_UPLOAD` has no string `answer.value`',
+        { answer }
+      );
+
+      return [];
+    } else {
+      return answer.value.split(',');
+    }
+  }
+
+  return [];
+};
+
+const collectSubtemplateData = async (answer: Answer) => {
+  const subQuestionaryIds = answer.value;
+  const attachmentIds: string[] = [];
+
+  const questionaryAnswers: Array<{ fields: Answer[] }> = [];
+
+  for (const subQuestionaryId of subQuestionaryIds) {
+    const subquestionarySteps = await questionaryDataSource.getQuestionarySteps(
+      subQuestionaryId
+    );
+    if (subquestionarySteps.length === 0) {
+      continue;
+    }
+    const firstStepTopicId = subquestionarySteps[0].topic.id; // NOTE: for now only the first topic
+    const answers = getTopicActiveAnswers(
+      subquestionarySteps!,
+      firstStepTopicId
+    );
+
+    for (const answer of answers) {
+      attachmentIds.push(...getFileAttachmentIds(answer));
+    }
+
+    questionaryAnswers.push({
+      fields: answers,
+    });
+  }
+
+  return {
+    questionaryAnswers,
+    attachmentIds,
+  };
+};
+
+const collectProposalPDFData = async (
+  proposalId: number,
+  user: UserWithRole
+): Promise<ProposalPDFData> => {
+  const UserAuthorization = baseContext.userAuthorization;
+  const proposal = await baseContext.queries.proposal.get(user, proposalId);
+
+  // Authenticate user
+  if (!proposal || !UserAuthorization.hasAccessRights(user, proposal)) {
+    throw new Error('User was not allowed to download PDF');
+  }
+
+  const queries = baseContext.queries.questionary;
+
+  const questionarySteps = await queries.getQuestionarySteps(
+    user,
+    proposal.questionaryId
+  );
+
+  if (isRejection(questionarySteps) || questionarySteps == null) {
+    throw new Error('Could not fetch questionary');
+  }
+
+  const principalInvestigator = await baseContext.queries.user.getBasic(
+    user,
+    proposal.proposerId
+  );
+  const coProposers = await baseContext.queries.user.getProposers(
+    user,
+    proposalId
+  );
+
+  if (!principalInvestigator || !coProposers) {
+    throw new Error('User was not PI or co-proposer');
+  }
+
+  const out: ProposalPDFData = {
+    proposal,
+    principalInvestigator,
+    coProposers,
+    questionarySteps: [],
+    attachmentIds: [],
+    filename: `${proposal.created.getUTCFullYear()}_${
+      principalInvestigator.lastname
+    }_${proposal.shortCode}.pdf`,
+  };
+
+  // Information from each topic in proposal
+  for (const step of questionarySteps) {
+    if (!step) {
+      console.error('step not found', questionarySteps);
+
+      throw 'Could not download generated PDF';
+    }
+
+    const topic = step.topic;
+    const answers = getTopicActiveAnswers(questionarySteps, topic.id);
+
+    const questionaryAttachmentIds = [];
+
+    for (let i = 0; i < answers.length; i++) {
+      const answer = answers[i];
+
+      questionaryAttachmentIds.push(...getFileAttachmentIds(answer));
+
+      if (answer.question.dataType === DataType.SUBTEMPLATE) {
+        const {
+          attachmentIds,
+          questionaryAnswers,
+        } = await collectSubtemplateData(answer);
+
+        answers[i].value = questionaryAnswers;
+        questionaryAttachmentIds.push(...attachmentIds);
+      }
+    }
+
+    out.questionarySteps.push({
+      ...step,
+      fields: answers,
+    });
+    out.attachmentIds.push(...questionaryAttachmentIds);
+  }
+
+  if (UserAuthorization.isReviewerOfProposal(user, proposal.id)) {
+    const technicalReview = await baseContext.queries.review.technicalReviewForProposal(
+      user,
+      proposal.id
+    );
+    if (technicalReview) {
+      out.technicalReview;
+    }
+  }
+
+  return out;
+};
+
+router.get('/proposal/download/:proposal_ids', async (req: any, res) => {
+  try {
+    const decoded = verifyToken<AuthJwtPayload>(req.cookies.token);
+    const proposalIds: number[] = req.params.proposal_ids
+      .split(',')
+      .map((n: string) => parseInt(n));
+
+    const user = await baseContext.queries.user.getAgent(decoded.user.id);
+
+    if (user == null) {
+      throw new Error('Could not find user');
+    }
+
+    const userWithRole = { ...user, currentRole: decoded.currentRole };
+
+    const data = await Promise.all(
+      proposalIds.map(proposalId =>
+        collectProposalPDFData(proposalId, userWithRole)
+      )
+    );
+
+    const pdfReq = request
+      .post(process.env.GENERATE_PROPOSAL_PDF_ENDPOINT!, { json: data })
+      .on('response', pdfResp => {
+        if (pdfResp.statusCode !== 200) {
+          const buffer: Buffer[] = [];
+          // TODO: handle if chunk is string
+          pdfReq.on('data', chunk => buffer.push(chunk as Buffer));
+          pdfReq.on('complete', () => {
+            const body = Buffer.concat(buffer).toString();
+
+            logger.logError('Failed to generate PDF', { response: body });
+          });
+          res.status(500).send('Failed to generate PDF');
+        } else {
+          res.setHeader(
+            'Content-Disposition',
+            contentDisposition(
+              data.length > 1 ? 'proposals.pdf' : data[0].filename
+            )
+          );
+
+          pdfResp.pipe(res);
+        }
+      })
+      .on('error', err => {
+        logger.logException('Could not download generated PDF', err);
+        res.status(500).send('Could not download generated PDF');
+      });
+  } catch (e) {
+    logger.logException('Could not download generated PDF', e);
+    res.status(500).send('Could not download generated PDF');
+  }
+});
+
+export default function proposalDownload() {
+  return router;
+}


### PR DESCRIPTION
## Description

Added support for an external, plug-in PDF creator, on the backend we just collect the data we want in the PDF and we send it to the external service. The current solution waits for the PDF, in the future it should be async and poll based.

## Motivation and Context

The previous solution uses hard coded templates / structure, and it's hard to extend or add support for new PDFs.
The goal here is to collect the information we need send it to an external system which handles the PDF creation.

## How Has This Been Tested

Currently there are no tests, will be added in a different ticket/PR.

## Fixes

https://jira.esss.lu.se/browse/SWAP-1143

## Changes

- new code added which focuses on collecting the data
- feature flag added to use the old system until it's completely removed and tests added

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
