### PR TITLE
Swap 1150 Standardize QuestionaryComponent

### DIFF
--- a/db_patches/0068_ConvertSubtemplateToSampleDeclaration.sql
+++ b/db_patches/0068_ConvertSubtemplateToSampleDeclaration.sql
@@ -1,0 +1,22 @@
+DO
+$$
+BEGIN
+	IF register_patch('0068_ConvertSubtemplateToSampleDeclaration.sql', 'jekabskarklins', 'Convert Subtemplate To Sample Declaration', '2020-10-28') THEN
+	BEGIN
+
+    ALTER TABLE questions
+	DROP CONSTRAINT "questions_data_type_fkey";
+
+	ALTER TABLE questions 
+	ADD CONSTRAINT questions_data_type_fkey 
+	FOREIGN KEY (data_type) 
+	REFERENCES question_datatypes(question_datatype_id) 
+	ON UPDATE CASCADE;
+
+	UPDATE question_datatypes  SET question_datatype_id = 'SAMPLE_DECLARATION' WHERE question_datatype_id='SUBTEMPLATE';
+
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/datasources/mockups/QuestionaryDataSource.ts
+++ b/src/datasources/mockups/QuestionaryDataSource.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { EvaluatorOperator } from '../../models/ConditionEvaluator';
-import { createConfig } from '../../models/ProposalModelFunctions';
 import {
   Questionary,
   QuestionaryStep,
   Answer,
   AnswerBasic,
 } from '../../models/Questionary';
+import { createConfig } from '../../models/questionTypes/QuestionRegistry';
 import {
   DataType,
   FieldCondition,
@@ -62,12 +62,15 @@ export const dummyQuestionFactory = (
 export const dummyQuestionTemplateRelationFactory = (
   values?: DeepPartial<QuestionTemplateRelation>
 ): QuestionTemplateRelation => {
-  return new QuestionTemplateRelation(
+  const relation = new QuestionTemplateRelation(
     dummyQuestionFactory(values?.question),
     values?.sortOrder || Math.round(Math.random() * 100),
     values?.topicId || Math.round(Math.random() * 10),
-    new BooleanConfig()
+    (values?.config as any) || new BooleanConfig(),
+    values?.dependency as any
   );
+
+  return relation;
 };
 
 const create1Topic3FieldWithDependenciesQuestionarySteps = () => {
@@ -84,7 +87,7 @@ const create1Topic3FieldWithDependenciesQuestionarySteps = () => {
               naturalKey: 'ttl_general',
               dataType: DataType.EMBELLISHMENT,
               config: createConfig<EmbellishmentConfig>(
-                new EmbellishmentConfig(),
+                DataType.EMBELLISHMENT,
                 {
                   plain: 'General information',
                   html: '<h1>General information</h1>',
@@ -103,7 +106,7 @@ const create1Topic3FieldWithDependenciesQuestionarySteps = () => {
               naturalKey: 'has_links_with_industry',
               dataType: DataType.SELECTION_FROM_OPTIONS,
               config: createConfig<SelectionFromOptionsConfig>(
-                new SelectionFromOptionsConfig(),
+                DataType.SELECTION_FROM_OPTIONS,
                 {
                   options: ['yes', 'no'],
                   variant: 'radio',
@@ -121,9 +124,10 @@ const create1Topic3FieldWithDependenciesQuestionarySteps = () => {
               proposalQuestionId: 'links_with_industry',
               naturalKey: 'links_with_industry',
               dataType: DataType.TEXT_INPUT,
-              config: createConfig<TextInputConfig>(new TextInputConfig(), {
+              config: createConfig<TextInputConfig>(DataType.TEXT_INPUT, {
                 placeholder: 'Please specify links with industry',
                 multiline: true,
+                required: true,
               }),
             }),
             dependency: new FieldDependency(

--- a/src/datasources/postgres/QuestionaryDataSource.ts
+++ b/src/datasources/postgres/QuestionaryDataSource.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { getDefaultAnswerValue } from '../../models/ProposalModelFunctions';
 import {
   Answer,
   AnswerBasic,
   Questionary,
   QuestionaryStep,
 } from '../../models/Questionary';
+import { getDefaultAnswerValue } from '../../models/questionTypes/QuestionRegistry';
 import { logger } from '../../utils/Logger';
 import { QuestionaryDataSource } from '../QuestionaryDataSource';
 import database from './database';

--- a/src/datasources/postgres/records.spec.ts
+++ b/src/datasources/postgres/records.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { createConfig } from '../../models/questionTypes/QuestionRegistry';
 import 'reflect-metadata';
+import { createConfig } from '../../models/questionTypes/QuestionRegistry';
 import { DataType } from '../../models/Template';
 import {
   BooleanConfig,

--- a/src/datasources/postgres/records.spec.ts
+++ b/src/datasources/postgres/records.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
+import { createConfig } from '../../models/questionTypes/QuestionRegistry';
 import 'reflect-metadata';
-import { createConfig } from '../../models/ProposalModelFunctions';
+import { DataType } from '../../models/Template';
 import {
   BooleanConfig,
   TextInputConfig,
@@ -9,7 +10,7 @@ import {
 test('Should able to create boolean config', () => {
   const isRequired = true;
   const smallLabel = 'some text';
-  const config = createConfig<BooleanConfig>(new BooleanConfig(), {
+  const config = createConfig<BooleanConfig>(DataType.BOOLEAN, {
     required: isRequired,
     small_label: 'some text',
   });
@@ -20,7 +21,7 @@ test('Should able to create boolean config', () => {
 test('Should able to create text input config', () => {
   const isRequired = false;
   const tooltip = 'This is tooltip';
-  const config = createConfig<TextInputConfig>(new TextInputConfig(), {
+  const config = createConfig<TextInputConfig>(DataType.TEXT_INPUT, {
     required: isRequired,
     tooltip: tooltip,
   });

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -3,9 +3,9 @@ import { FileMetadata } from '../../models/Blob';
 import { Call } from '../../models/Call';
 import { EvaluatorOperator } from '../../models/ConditionEvaluator';
 import { Proposal } from '../../models/Proposal';
-import { createConfigByType } from '../../models/ProposalModelFunctions';
 import { ProposalView } from '../../models/ProposalView';
-import { Questionary, AnswerBasic } from '../../models/Questionary';
+import { AnswerBasic, Questionary } from '../../models/Questionary';
+import { createConfig } from '../../models/questionTypes/QuestionRegistry';
 import { Sample } from '../../models/Sample';
 import {
   DataType,
@@ -13,10 +13,10 @@ import {
   FieldDependency,
   Question,
   QuestionTemplateRelation,
+  Template,
   TemplateCategory,
   Topic,
 } from '../../models/Template';
-import { Template } from '../../models/Template';
 import { BasicUserDetails, User } from '../../models/User';
 
 // Interfaces corresponding exactly to database tables
@@ -383,7 +383,7 @@ export const createQuestionObject = (question: QuestionRecord) => {
     question.natural_key,
     question.data_type as DataType,
     question.question,
-    createConfigByType(question.data_type as DataType, question.default_config)
+    createConfig<any>(question.data_type as DataType, question.default_config)
   );
 };
 
@@ -479,11 +479,11 @@ export const createQuestionTemplateRelationObject = (
       record.natural_key,
       record.data_type as DataType,
       record.question,
-      createConfigByType(record.data_type as DataType, record.default_config)
+      createConfig<any>(record.data_type as DataType, record.default_config)
     ),
     record.topic_id,
     record.sort_order,
-    createConfigByType(record.data_type as DataType, record.config),
+    createConfig<any>(record.data_type as DataType, record.config),
     record.dependency_question_id && record.dependency_condition
       ? new FieldDependency(
           record.question_id,

--- a/src/middlewares/pdfFactory.ts
+++ b/src/middlewares/pdfFactory.ts
@@ -163,7 +163,7 @@ const collectProposalPDFData = async (
 
       questionaryAttachmentIds.push(...getFileAttachmentIds(answer));
 
-      if (answer.question.dataType === DataType.SUBTEMPLATE) {
+      if (answer.question.dataType === DataType.SAMPLE_DECLARATION) {
         const {
           attachmentIds,
           questionaryAnswers,

--- a/src/models/ProposalModelFunctions.spec.ts
+++ b/src/models/ProposalModelFunctions.spec.ts
@@ -1,0 +1,75 @@
+import 'reflect-metadata';
+import {
+  dummyQuestionTemplateRelationFactory,
+  QuestionaryDataSourceMock,
+} from '../datasources/mockups/QuestionaryDataSource';
+import { BooleanConfig } from '../resolvers/types/FieldConfig';
+import {
+  areDependenciesSatisfied,
+  getFieldById,
+  isMatchingConstraints,
+} from './ProposalModelFunctions';
+import { Answer } from './Questionary';
+import { createConfig } from './questionTypes/QuestionRegistry';
+import { DataType } from './Template';
+
+const dummyQuestionaryDataSource = new QuestionaryDataSourceMock();
+
+beforeEach(() => {
+  dummyQuestionaryDataSource.init();
+});
+
+it('Field config "required=true" should make field required', async () => {
+  const question = dummyQuestionTemplateRelationFactory({
+    question: {
+      dataType: DataType.BOOLEAN,
+    },
+    config: createConfig<BooleanConfig>(DataType.BOOLEAN, { required: true }),
+  });
+
+  expect(isMatchingConstraints(question, false)).toBe(false);
+  expect(isMatchingConstraints(question, true)).toBe(true);
+});
+
+it('Field config "required=false" should make field not required', async () => {
+  const question = dummyQuestionTemplateRelationFactory({
+    question: {
+      dataType: DataType.TEXT_INPUT,
+    },
+    config: createConfig<BooleanConfig>(DataType.TEXT_INPUT, {
+      required: false,
+    }),
+  });
+  expect(isMatchingConstraints(question, false)).toBe(true);
+  expect(isMatchingConstraints(question, true)).toBe(true);
+});
+
+it('Dependencies should be sattisfied if value matches', async () => {
+  const questionarySteps = await dummyQuestionaryDataSource.getQuestionarySteps(
+    1
+  );
+  const dependee = getFieldById(
+    questionarySteps,
+    'has_links_with_industry'
+  ) as Answer;
+  const depender = getFieldById(
+    questionarySteps,
+    'links_with_industry'
+  ) as Answer;
+
+  expect(
+    areDependenciesSatisfied(
+      questionarySteps,
+      depender.question.proposalQuestionId
+    )
+  ).toBe(true);
+
+  dependee.value = 'no';
+
+  expect(
+    areDependenciesSatisfied(
+      questionarySteps,
+      depender.question.proposalQuestionId
+    )
+  ).toBe(false);
+});

--- a/src/models/ProposalModelFunctions.spec.ts
+++ b/src/models/ProposalModelFunctions.spec.ts
@@ -40,8 +40,8 @@ it('Field config "required=false" should make field not required', async () => {
       required: false,
     }),
   });
-  expect(isMatchingConstraints(question, false)).toBe(true);
-  expect(isMatchingConstraints(question, true)).toBe(true);
+  expect(isMatchingConstraints(question, 'text')).toBe(true);
+  expect(isMatchingConstraints(question, '')).toBe(true);
 });
 
 it('Dependencies should be sattisfied if value matches', async () => {

--- a/src/models/ProposalModelFunctions.ts
+++ b/src/models/ProposalModelFunctions.ts
@@ -1,37 +1,14 @@
-/* eslint-disable @typescript-eslint/camelcase */
-import {
-  BooleanConfig,
-  DateConfig,
-  EmbellishmentConfig,
-  FieldConfigType,
-  FileUploadConfig,
-  ProposalBasisConfig,
-  SampleBasisConfig,
-  SelectionFromOptionsConfig,
-  SubtemplateConfig,
-  TextInputConfig,
-} from '../resolvers/types/FieldConfig';
-import { logger } from '../utils/Logger';
 import { ConditionEvaluator } from './ConditionEvaluator';
 import { Answer, QuestionaryStep } from './Questionary';
+import { getQuestionDefinition } from './questionTypes/QuestionRegistry';
 import {
-  DataType,
-  DataTypeSpec,
   FieldDependency,
   QuestionTemplateRelation,
-  TemplateCategoryId,
   TemplateStep,
 } from './Template';
 type AbstractField = QuestionTemplateRelation | Answer;
 type AbstractCollection = TemplateStep[] | QuestionaryStep[];
-export function getDataTypeSpec(type: DataType): DataTypeSpec {
-  switch (type) {
-    case DataType.EMBELLISHMENT:
-      return { readonly: true };
-    default:
-      return { readonly: false };
-  }
-}
+
 export function getTopicById(collection: AbstractCollection, topicId: number) {
   const step = collection.find(step => step.topic.id === topicId);
 
@@ -66,6 +43,7 @@ export function getAllFields(collection: AbstractCollection) {
 
   return allFields;
 }
+
 export function isDependencySatisfied(
   collection: QuestionaryStep[],
   dependency: FieldDependency | undefined
@@ -73,6 +51,7 @@ export function isDependencySatisfied(
   if (!dependency?.condition) {
     return true;
   }
+
   const { condition, params } = dependency.condition;
   const field = getFieldById(collection, dependency.dependencyId) as
     | Answer
@@ -93,11 +72,13 @@ export function isDependencySatisfied(
       .isSatisfied(field, params)
   );
 }
+
 export function areDependenciesSatisfied(
   questionary: QuestionaryStep[],
   fieldId: string
 ) {
   const field = getFieldById(questionary, fieldId);
+
   if (!field) {
     return true;
   }
@@ -105,170 +86,13 @@ export function areDependenciesSatisfied(
   return isDependencySatisfied(questionary, field.dependency);
 }
 
-class BaseValidator implements ConstraintValidator {
-  constructor(private dataType?: DataType | undefined) {}
-
-  validate(value: any, field: Answer) {
-    if (this.dataType && field.question.dataType !== this.dataType) {
-      throw new Error('Field validator ');
-    }
-    if (field.question.config.required && !value) {
-      return false;
-    }
-
-    return true;
-  }
-}
-
-class TextInputValidator extends BaseValidator {
-  constructor() {
-    super(DataType.TEXT_INPUT);
-  }
-  validate(value: any, field: Answer) {
-    if (!super.validate(value, field)) {
-      return false;
-    }
-    const config = field.question.config as TextInputConfig;
-    if (config.min && value && value.length < config.min) {
-      return false;
-    }
-    if (config.max && value && value.length > config.max) {
-      return false;
-    }
-
-    return true;
-  }
-}
-
-class SelectFromOptionsInputValidator extends BaseValidator {
-  constructor() {
-    super(DataType.SELECTION_FROM_OPTIONS);
-  }
-  validate(value: any, field: Answer) {
-    const config = field.question.config as SelectionFromOptionsConfig;
-    if (!super.validate(value, field)) {
-      return false;
-    }
-
-    if (config.required && config.options!.indexOf(value) === -1) {
-      return false;
-    }
-
-    return true;
-  }
-}
-
-const validatorMap = new Map<DataType, ConstraintValidator>();
-validatorMap.set(DataType.TEXT_INPUT, new TextInputValidator());
-validatorMap.set(
-  DataType.SELECTION_FROM_OPTIONS,
-  new SelectFromOptionsInputValidator()
-);
-
 export function isMatchingConstraints(
-  value: any,
-  field: QuestionTemplateRelation
+  questionTemplateRelation: QuestionTemplateRelation,
+  value: any
 ): boolean {
-  const val = JSON.parse(value).value;
-  const validator =
-    validatorMap.get(field.question.dataType) || new BaseValidator();
+  const definition = getQuestionDefinition(
+    questionTemplateRelation.question.dataType
+  );
 
-  return validator.validate(val, field);
-}
-
-interface ConstraintValidator {
-  validate(value: any, field: QuestionTemplateRelation): boolean;
-}
-
-const baseDefaultConfig = { required: false, small_label: '', tooltip: '' };
-const defaultConfigs = new Map<
-  string,
-  | BooleanConfig
-  | DateConfig
-  | EmbellishmentConfig
-  | FileUploadConfig
-  | SelectionFromOptionsConfig
-  | TextInputConfig
-  | SampleBasisConfig
-  | SubtemplateConfig
->();
-defaultConfigs.set('BooleanConfig', { ...baseDefaultConfig });
-defaultConfigs.set('DateConfig', { ...baseDefaultConfig });
-
-defaultConfigs.set('EmbellishmentConfig', {
-  plain: '',
-  html: '',
-  omitFromPdf: false,
-  ...baseDefaultConfig,
-});
-defaultConfigs.set('FileUploadConfig', {
-  max_files: 1,
-  file_type: [],
-  ...baseDefaultConfig,
-});
-defaultConfigs.set('SelectionFromOptionsConfig', {
-  options: [],
-  variant: 'radio',
-  ...baseDefaultConfig,
-});
-defaultConfigs.set('TextInputConfig', {
-  multiline: false,
-  isHtmlQuestion: false,
-  placeholder: '',
-  ...baseDefaultConfig,
-});
-
-defaultConfigs.set('SampleBasisConfig', {
-  titlePlaceholder: 'Title',
-  ...baseDefaultConfig,
-});
-
-defaultConfigs.set('SubtemplateConfig', {
-  templateId: 0,
-  templateCategory: TemplateCategoryId[TemplateCategoryId.SAMPLE_DECLARATION],
-  ...baseDefaultConfig,
-});
-
-const f = new Map<string, () => typeof FieldConfigType>();
-f.set(DataType.BOOLEAN, () => new BooleanConfig());
-f.set(DataType.DATE, () => new DateConfig());
-f.set(DataType.EMBELLISHMENT, () => new EmbellishmentConfig());
-f.set(DataType.FILE_UPLOAD, () => new FileUploadConfig());
-f.set(DataType.SELECTION_FROM_OPTIONS, () => new SelectionFromOptionsConfig());
-f.set(DataType.TEXT_INPUT, () => new TextInputConfig());
-f.set(DataType.SUBTEMPLATE, () => new SubtemplateConfig());
-f.set(DataType.SAMPLE_BASIS, () => new SampleBasisConfig());
-f.set(DataType.PROPOSAL_BASIS, () => new ProposalBasisConfig());
-
-export function createConfig<T extends typeof FieldConfigType>(
-  config: T,
-  init: Partial<T> | string = {}
-): T {
-  const defaults = defaultConfigs.get(config.constructor.name);
-  const initValues = typeof init === 'string' ? JSON.parse(init) : init;
-  Object.assign(config, { ...defaults, ...initValues });
-
-  return config;
-}
-
-export function createConfigByType(dataType: DataType, init: object | string) {
-  const configCreator = f.get(dataType)!;
-  if (!configCreator) {
-    logger.logError('ConfigCreator not implemented', { dataType });
-    throw new Error('ConfigCreator not implemented');
-  }
-
-  return createConfig(configCreator(), init);
-}
-
-export function getDefaultAnswerValue(type: DataType): any {
-  switch (type) {
-    case DataType.BOOLEAN:
-      return false;
-    case DataType.FILE_UPLOAD:
-    case DataType.SUBTEMPLATE:
-      return [];
-    default:
-      return '';
-  }
+  return definition.validate(questionTemplateRelation, value);
 }

--- a/src/models/Template.ts
+++ b/src/models/Template.ts
@@ -17,7 +17,7 @@ export enum DataType {
   FILE_UPLOAD = 'FILE_UPLOAD',
   SELECTION_FROM_OPTIONS = 'SELECTION_FROM_OPTIONS',
   TEXT_INPUT = 'TEXT_INPUT',
-  SUBTEMPLATE = 'SUBTEMPLATE',
+  SAMPLE_DECLARATION = 'SAMPLE_DECLARATION',
   SAMPLE_BASIS = 'SAMPLE_BASIS',
   PROPOSAL_BASIS = 'PROPOSAL_BASIS',
 }
@@ -68,10 +68,6 @@ export enum TemplateCategoryId {
 
 export class FieldCondition {
   constructor(public condition: EvaluatorOperator, public params: any) {}
-}
-
-export interface DataTypeSpec {
-  readonly: boolean;
 }
 
 export class Template {

--- a/src/models/questionTypes/Boolean.ts
+++ b/src/models/questionTypes/Boolean.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { BooleanConfig } from '../../resolvers/types/FieldConfig';
+import { DataType, QuestionTemplateRelation } from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const booleanDefinition: Question = {
+  dataType: DataType.BOOLEAN,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.BOOLEAN) {
+      throw new Error('DataType should be BOOLEAN');
+    }
+
+    const config = field.config as BooleanConfig;
+    if (config.required && !value) {
+      return false;
+    }
+
+    return true;
+  },
+  createBlankConfig: (): BooleanConfig => {
+    const config = new BooleanConfig();
+    config.small_label = '';
+    config.required = false;
+    config.tooltip = '';
+
+    return config;
+  },
+  isReadOnly: false,
+  defaultAnswer: false,
+};

--- a/src/models/questionTypes/Date.ts
+++ b/src/models/questionTypes/Date.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { DateConfig } from '../../resolvers/types/FieldConfig';
+import { DataType, QuestionTemplateRelation } from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const dateDefinition: Question = {
+  dataType: DataType.DATE,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.DATE) {
+      throw new Error('DataType should be DATE');
+    }
+    const config = field.config as DateConfig;
+    if (config.required && !value) {
+      return false;
+    }
+
+    return true;
+  },
+  createBlankConfig: (): DateConfig => {
+    const config = new DateConfig();
+    config.small_label = '';
+    config.required = false;
+    config.tooltip = '';
+
+    return config;
+  },
+  isReadOnly: false,
+  defaultAnswer: '',
+};

--- a/src/models/questionTypes/Embellishment.ts
+++ b/src/models/questionTypes/Embellishment.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { EmbellishmentConfig } from '../../resolvers/types/FieldConfig';
+import { DataType, QuestionTemplateRelation } from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const embellishmentDefinition: Question = {
+  dataType: DataType.EMBELLISHMENT,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.EMBELLISHMENT) {
+      throw new Error('DataType should be EMBELLISHMENT');
+    }
+
+    return true;
+  },
+  createBlankConfig: (): EmbellishmentConfig => {
+    const config = new EmbellishmentConfig();
+    config.html = '';
+    config.plain = '';
+    config.omitFromPdf = false;
+
+    return config;
+  },
+  isReadOnly: true,
+  defaultAnswer: null,
+};

--- a/src/models/questionTypes/FileUpload.ts
+++ b/src/models/questionTypes/FileUpload.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { FileUploadConfig } from '../../resolvers/types/FieldConfig';
+import { QuestionTemplateRelation } from '../../resolvers/types/QuestionTemplateRelation';
+import { DataType } from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const fileUploadDefinition: Question = {
+  dataType: DataType.FILE_UPLOAD,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.FILE_UPLOAD) {
+      throw new Error('DataType should be FILE_UPLOAD');
+    }
+    const config = field.config as FileUploadConfig;
+    if (config.required && !value) {
+      return false;
+    }
+
+    return true;
+  },
+  createBlankConfig: (): FileUploadConfig => {
+    const config = new FileUploadConfig();
+    config.small_label = '';
+    config.required = false;
+    config.tooltip = '';
+    config.file_type = [];
+    config.max_files = 0;
+
+    return config;
+  },
+  isReadOnly: false,
+  defaultAnswer: [],
+};

--- a/src/models/questionTypes/ProposalBasis.ts
+++ b/src/models/questionTypes/ProposalBasis.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { ProposalBasisConfig } from '../../resolvers/types/FieldConfig';
+import { DataType, QuestionTemplateRelation } from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const proposalBasisDefinition: Question = {
+  dataType: DataType.PROPOSAL_BASIS,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.PROPOSAL_BASIS) {
+      throw new Error('DataType should be PROPOSAL_BASIS');
+    }
+
+    return true;
+  },
+  createBlankConfig: (): ProposalBasisConfig => {
+    const config = new ProposalBasisConfig();
+    config.tooltip = '';
+
+    return config;
+  },
+  isReadOnly: true,
+  defaultAnswer: null,
+};

--- a/src/models/questionTypes/QuestionRegistry.ts
+++ b/src/models/questionTypes/QuestionRegistry.ts
@@ -1,0 +1,72 @@
+import { logger } from '../../utils/Logger';
+import { DataType, QuestionTemplateRelation } from '../Template';
+import { booleanDefinition } from './Boolean';
+import { dateDefinition } from './Date';
+import { embellishmentDefinition } from './Embellishment';
+import { fileUploadDefinition } from './FileUpload';
+import { proposalBasisDefinition } from './ProposalBasis';
+import { sampleBasisDefinition } from './SampleBasis';
+import { sampleDeclarationDefinition } from './SampleDeclaration';
+import { selectionFromOptionsDefinition } from './SelectionFromOptions';
+import { textInputDefinition } from './TextInput';
+
+export interface Question {
+  dataType: DataType;
+  validate: (field: QuestionTemplateRelation, value: any) => boolean;
+  createBlankConfig: () => any;
+  isReadOnly: boolean;
+  defaultAnswer: any;
+}
+
+// Add new component definitions here
+const registry = [
+  booleanDefinition,
+  dateDefinition,
+  embellishmentDefinition,
+  fileUploadDefinition,
+  selectionFromOptionsDefinition,
+  textInputDefinition,
+  sampleDeclarationDefinition,
+  proposalBasisDefinition,
+  sampleBasisDefinition,
+];
+
+const componentMap = new Map<DataType, Question>();
+registry.forEach(definition =>
+  componentMap.set(definition.dataType, definition)
+);
+
+export const getQuestionDefinition = (dataType: DataType) => {
+  const definition = componentMap.get(dataType);
+  if (!definition) {
+    logger.logError('Tried to obtain non-existing definition', { dataType });
+    throw new Error('Tried to obtain non-existing definition');
+  }
+
+  return definition;
+};
+
+/**
+ * Convenience function to create config for datatype with initial data
+ */
+export function createConfig<T>(
+  dataType: DataType,
+  init: Partial<T> | string = {}
+): T {
+  const definition = getQuestionDefinition(dataType);
+  const config: T = definition.createBlankConfig();
+  const initValues: Partial<T> =
+    typeof init === 'string' ? JSON.parse(init) : init;
+  Object.assign(config, { ...initValues });
+
+  return config;
+}
+
+/**
+ * Convenience function to get default value for datatype
+ */
+export function getDefaultAnswerValue(dataType: DataType): any {
+  const definition = getQuestionDefinition(dataType);
+
+  return definition.defaultAnswer;
+}

--- a/src/models/questionTypes/SampleBasis.ts
+++ b/src/models/questionTypes/SampleBasis.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { SampleBasisConfig } from '../../resolvers/types/FieldConfig';
+import { DataType, QuestionTemplateRelation } from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const sampleBasisDefinition: Question = {
+  dataType: DataType.SAMPLE_BASIS,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.SAMPLE_BASIS) {
+      throw new Error('DataType should be SAMPLE_BASIS');
+    }
+
+    return true;
+  },
+  createBlankConfig: (): SampleBasisConfig => {
+    const config = new SampleBasisConfig();
+    config.titlePlaceholder = 'Title';
+
+    return config;
+  },
+  isReadOnly: true,
+  defaultAnswer: null,
+};

--- a/src/models/questionTypes/SampleDeclaration.ts
+++ b/src/models/questionTypes/SampleDeclaration.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { SubtemplateConfig } from '../../resolvers/types/FieldConfig';
+import {
+  DataType,
+  QuestionTemplateRelation,
+  TemplateCategoryId,
+} from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const sampleDeclarationDefinition: Question = {
+  dataType: DataType.SAMPLE_DECLARATION,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.SAMPLE_DECLARATION) {
+      throw new Error('DataType should be SAMPLE_DECLARATION');
+    }
+
+    return true;
+  },
+  createBlankConfig: (): SubtemplateConfig => {
+    const config = new SubtemplateConfig();
+    config.addEntryButtonLabel = 'Add';
+    config.maxEntries = 0;
+    config.templateCategory =
+      TemplateCategoryId[TemplateCategoryId.SAMPLE_DECLARATION];
+    config.templateId = 0;
+    config.small_label = '';
+    config.required = false;
+
+    return config;
+  },
+  isReadOnly: false,
+  defaultAnswer: [],
+};

--- a/src/models/questionTypes/SelectionFromOptions.ts
+++ b/src/models/questionTypes/SelectionFromOptions.ts
@@ -10,7 +10,7 @@ export const selectionFromOptionsDefinition: Question = {
       throw new Error('DataType should be SELECTION_FROM_OPTIONS');
     }
 
-    const config = field.question.config as SelectionFromOptionsConfig;
+    const config = field.config as SelectionFromOptionsConfig;
     if (config.required && !value) {
       return false;
     }

--- a/src/models/questionTypes/SelectionFromOptions.ts
+++ b/src/models/questionTypes/SelectionFromOptions.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { SelectionFromOptionsConfig } from '../../resolvers/types/FieldConfig';
+import { DataType, QuestionTemplateRelation } from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const selectionFromOptionsDefinition: Question = {
+  dataType: DataType.SELECTION_FROM_OPTIONS,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.SELECTION_FROM_OPTIONS) {
+      throw new Error('DataType should be SELECTION_FROM_OPTIONS');
+    }
+
+    const config = field.question.config as SelectionFromOptionsConfig;
+    if (config.required && !value) {
+      return false;
+    }
+
+    if (config.required && config.options!.indexOf(value) === -1) {
+      return false;
+    }
+
+    return true;
+  },
+  createBlankConfig: (): SelectionFromOptionsConfig => {
+    const config = new SelectionFromOptionsConfig();
+    config.small_label = '';
+    config.required = false;
+    config.tooltip = '';
+    config.variant = 'radio';
+    config.options = [];
+
+    return config;
+  },
+  isReadOnly: false,
+  defaultAnswer: '',
+};

--- a/src/models/questionTypes/TextInput.ts
+++ b/src/models/questionTypes/TextInput.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { ConfigBase, TextInputConfig } from '../../resolvers/types/FieldConfig';
+import { DataType, QuestionTemplateRelation } from '../Template';
+import { Question } from './QuestionRegistry';
+
+export const textInputDefinition: Question = {
+  dataType: DataType.TEXT_INPUT,
+  validate: (field: QuestionTemplateRelation, value: any) => {
+    if (field.question.dataType !== DataType.TEXT_INPUT) {
+      throw new Error('DataType should be TEXT_INPUT');
+    }
+    const config = field.question.config as TextInputConfig;
+    if (config.required && !value) {
+      return false;
+    }
+
+    if (config.min && value && value.length < config.min) {
+      return false;
+    }
+    if (config.max && value && value.length > config.max) {
+      return false;
+    }
+
+    return true;
+  },
+  createBlankConfig: (): ConfigBase => {
+    const config = new TextInputConfig();
+    config.required = false;
+    config.small_label = '';
+    config.tooltip = '';
+    config.htmlQuestion = '';
+    config.isHtmlQuestion = false;
+    config.min = null;
+    config.max = null;
+    config.multiline = false;
+    config.placeholder = '';
+
+    return config;
+  },
+  isReadOnly: false,
+  defaultAnswer: '',
+};

--- a/src/models/questionTypes/TextInput.ts
+++ b/src/models/questionTypes/TextInput.ts
@@ -9,7 +9,7 @@ export const textInputDefinition: Question = {
     if (field.question.dataType !== DataType.TEXT_INPUT) {
       throw new Error('DataType should be TEXT_INPUT');
     }
-    const config = field.question.config as TextInputConfig;
+    const config = field.config as TextInputConfig;
     if (config.required && !value) {
       return false;
     }

--- a/src/mutations/QuestionaryMutations.ts
+++ b/src/mutations/QuestionaryMutations.ts
@@ -64,9 +64,10 @@ export default class QuestionaryMutations {
 
           return rejection('INTERNAL_ERROR');
         }
+        const value = JSON.parse(answer.value).value;
         if (
           !isPartialSave &&
-          !isMatchingConstraints(answer.value, questionTemplateRelation)
+          !isMatchingConstraints(questionTemplateRelation, value)
         ) {
           this.logger.logError('User provided value not matching constraint', {
             answer,

--- a/src/mutations/TemplateMutations.ts
+++ b/src/mutations/TemplateMutations.ts
@@ -18,7 +18,7 @@ import {
 
 import { TemplateDataSource } from '../datasources/TemplateDataSource';
 import { Authorized, ValidateArgs } from '../decorators';
-import { createConfig } from '../models/ProposalModelFunctions';
+import { getQuestionDefinition } from '../models/questionTypes/QuestionRegistry';
 import { Roles } from '../models/Role';
 import {
   DataType,
@@ -230,7 +230,7 @@ export default class TemplateMutations {
         newFieldId, // natural key defaults to id
         dataType,
         'New question',
-        JSON.stringify(this.createBlankConfig(dataType))
+        JSON.stringify(getQuestionDefinition(dataType).createBlankConfig())
       )
       .then(question => question)
       .catch(err => {
@@ -400,27 +400,5 @@ export default class TemplateMutations {
 
         return rejection('INTERNAL_ERROR');
       });
-  }
-
-  private createBlankConfig(dataType: DataType): typeof FieldConfigType {
-    switch (dataType) {
-      case DataType.FILE_UPLOAD:
-        return createConfig<FileUploadConfig>(new FileUploadConfig());
-      case DataType.EMBELLISHMENT:
-        return createConfig<EmbellishmentConfig>(new EmbellishmentConfig(), {
-          plain: 'New embellishment',
-          html: '<p>New embellishment</p>',
-        });
-      case DataType.SELECTION_FROM_OPTIONS:
-        return createConfig<SelectionFromOptionsConfig>(
-          new SelectionFromOptionsConfig()
-        );
-      case DataType.SUBTEMPLATE:
-        return createConfig<SubtemplateConfig>(new SubtemplateConfig(), {
-          addEntryButtonLabel: 'Add',
-        });
-      default:
-        return new ConfigBase();
-    }
   }
 }

--- a/src/populate/index.ts
+++ b/src/populate/index.ts
@@ -12,8 +12,7 @@ import {
   templateDataSource,
   userDataSource,
 } from '../datasources';
-import database from '../datasources/postgres/database';
-import { createConfigByType } from '../models/ProposalModelFunctions';
+import { getQuestionDefinition } from '../models/questionTypes/QuestionRegistry';
 import { TechnicalReviewStatus } from '../models/TechnicalReview';
 import { DataType, TemplateCategoryId } from '../models/Template';
 import { UserRole } from '../models/User';
@@ -162,7 +161,9 @@ const createTemplates = async () => {
           questionId,
           DataType.TEXT_INPUT,
           `${faker.random.words(5)}?`,
-          JSON.stringify(createConfigByType(DataType.TEXT_INPUT, {}))
+          JSON.stringify(
+            getQuestionDefinition(DataType.TEXT_INPUT).createBlankConfig()
+          )
         );
       }, 10);
 

--- a/src/resolvers/types/FieldConfig.ts
+++ b/src/resolvers/types/FieldConfig.ts
@@ -13,7 +13,7 @@ export class ConfigBase {
 }
 
 @ObjectType()
-export class SampleBasisConfig extends ConfigBase {
+export class SampleBasisConfig {
   @Field(() => String)
   titlePlaceholder: string;
 }
@@ -25,7 +25,7 @@ export class BooleanConfig extends ConfigBase {}
 export class DateConfig extends ConfigBase {}
 
 @ObjectType()
-export class EmbellishmentConfig extends ConfigBase {
+export class EmbellishmentConfig {
   @Field(() => Boolean)
   omitFromPdf: boolean;
 
@@ -76,7 +76,7 @@ export class TextInputConfig extends ConfigBase {
 }
 
 @ObjectType()
-export class SubtemplateConfig extends ConfigBase {
+export class SubtemplateConfig {
   @Field(() => Int, { nullable: true })
   maxEntries: number | null;
 
@@ -88,10 +88,19 @@ export class SubtemplateConfig extends ConfigBase {
 
   @Field(() => String)
   addEntryButtonLabel: string;
+
+  @Field(() => String)
+  small_label: string;
+
+  @Field(() => Boolean)
+  required: boolean;
 }
 
 @ObjectType()
-export class ProposalBasisConfig extends ConfigBase {}
+export class ProposalBasisConfig {
+  @Field(() => String)
+  tooltip: string;
+}
 
 export const FieldConfigType = createUnionType({
   name: 'FieldConfig', // the name of the GraphQL union


### PR DESCRIPTION
## Description

This is purely a refactoring task. It does not add nor removes functionality but standardizes how QuestionaryComponents are implemented

Every component in the backend now implements a Question interface and by adding it to the registry it integrates into the questionary system. 

Here is the added documentation for more details.
https://github.com/UserOfficeProject/user-office-backend/wiki/How-to-create-new-questionary-component

## Motivation and Context

Since we expect to add more different types of components and that being the main way to extend functionality, components should be treated as components hiding behind an interface that can be added or removed from the system.

## How Has This Been Tested

- [x] Unit testing
- [x] Manual testing

## Fixes

SWAP-1150

## Changes

Questionary engine
Questionary components

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [x] All relevant doc has been updated



