### PR TITLE
Add stfc-user-programme as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @UserOfficeProject/stfc-user-programme


### PR DESCRIPTION
This is to trial using GitHub [`CODEOWNERS`](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners) to help us manage the incoming reviews on the STFC side. Code owners are available for public repos for free organisations; however, I'm not sure if the team allocation works for free organisations.

It adds `@UserOfficeProject\user-programme` as a code owner.

It hasn't been tested yet so we will need to watch out for the next PR.
