### PR TITLE
SWAP-1228 Table is missing data after SEP deactivation

### DIFF
--- a/db_patches/0073_UpdateProposalView.sql
+++ b/db_patches/0073_UpdateProposalView.sql
@@ -1,0 +1,47 @@
+DO
+$$
+BEGIN
+    IF register_patch('UpdateProposalView.sql', 'Peter Asztalos', 'Use SEP_Proposals for joining SEP', '2020-11-25') THEN
+
+        DROP VIEW proposal_table_view;
+
+        ALTER TABLE proposals DROP COLUMN sep_id;
+
+        CREATE VIEW proposal_table_view
+        AS
+        SELECT  p.proposal_id AS id,
+                p.title,
+                p.status_id AS proposal_status_id,
+                ps.name AS proposal_status_name,
+                ps.description AS proposal_status_description,
+                p.short_code,
+                p.rank_order,
+                p.final_status,
+                p.notified,
+                t.time_allocation,
+                t.status AS technical_review_status,
+                i.name AS instrument_name,
+                c.call_short_code,
+                s.code AS sep_code,
+                c.call_id,
+                i.instrument_id,
+                ( SELECT round(avg("SEP_Reviews".grade), 1) AS round
+                    FROM "SEP_Reviews"
+                    WHERE "SEP_Reviews".proposal_id = p.proposal_id) AS average,
+                ( SELECT round(stddev_pop("SEP_Reviews".grade), 1) AS round
+                    FROM "SEP_Reviews"
+                    WHERE "SEP_Reviews".proposal_id = p.proposal_id) AS deviation,
+                p.submitted
+        FROM proposals p
+                LEFT JOIN technical_review t ON t.proposal_id = p.proposal_id
+                LEFT JOIN instrument_has_proposals ihp ON ihp.proposal_id = p.proposal_id
+                LEFT JOIN proposal_statuses ps ON ps.proposal_status_id = p.status_id
+                LEFT JOIN instruments i ON i.instrument_id = ihp.instrument_id
+                LEFT JOIN call c ON c.call_id = p.call_id
+                LEFT JOIN "SEP_Proposals" sp ON sp.proposal_id = p.proposal_id
+                LEFT JOIN "SEPs" s ON s.sep_id = sp.sep_id;
+
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -72,7 +72,7 @@ export interface ProposalViewRecord {
   readonly technical_review_status: number;
   readonly instrument_name: string;
   readonly call_short_code: string;
-  readonly code: string;
+  readonly sep_code: string;
   readonly average: number;
   readonly deviation: number;
   readonly instrument_id: number;
@@ -454,7 +454,7 @@ export const createProposalViewObject = (proposal: ProposalViewRecord) => {
     proposal.technical_review_status,
     proposal.instrument_name,
     proposal.call_short_code,
-    proposal.code,
+    proposal.sep_code,
     proposal.average,
     proposal.deviation,
     proposal.instrument_id,

--- a/src/models/ProposalView.ts
+++ b/src/models/ProposalView.ts
@@ -14,7 +14,7 @@ export class ProposalView {
     public technicalStatus: TechnicalReviewStatus,
     public instrumentName: string,
     public callShortCode: string,
-    public sepShortCode: string,
+    public sepCode: string,
     public reviewAverage: number,
     public reviewDeviation: number,
     public instrumentId: number,

--- a/src/resolvers/types/ProposalView.ts
+++ b/src/resolvers/types/ProposalView.ts
@@ -51,7 +51,7 @@ export class ProposalView implements Partial<ProposalOrigin> {
   public callShortCode: string;
 
   @Field(() => String, { nullable: true })
-  public sepShortCode: string;
+  public sepCode: string;
 
   @Field(() => Float, { nullable: true })
   public reviewAverage: number;


### PR DESCRIPTION
## Description

This PR aims to fix an issue related to the Proposals table, where the connected SEP doesn't show up.
<!--- Describe your changes in detail -->

## Motivation and Context

The Proposals table uses a view to display the relevant information we need, this view used an obsolete field to populate the SEP code.
This PR removes the unused field and updates the view.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] Manual testing
- [x] e2e tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1228
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- `proposal_view_table` updated
- obsolete `sep_id` field removed
- field names updated
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/107
https://github.com/UserOfficeProject/user-office-backend/pull/86
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
