### PR TITLE
SWAP-1230 docx upload fix #resolved

### DIFF
--- a/db_patches/0072_ExtendMimeTypeField.sql
+++ b/db_patches/0072_ExtendMimeTypeField.sql
@@ -1,0 +1,15 @@
+DO
+$$
+BEGIN
+	IF register_patch('ExtendMimeTypeField.sql', 'jekabskarklins', 'Extends mime type field length', '2020-11-23') THEN
+        
+
+
+        ALTER TABLE files ALTER COLUMN mime_type TYPE character varying(256);
+
+
+
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/middlewares/files.ts
+++ b/src/middlewares/files.ts
@@ -1,4 +1,4 @@
-import { unlink, existsSync } from 'fs';
+import { existsSync, unlink } from 'fs';
 
 import express, { Request, Response } from 'express';
 import multer from 'multer';
@@ -49,8 +49,13 @@ const files = () => {
         size,
         path
       );
-      res.status(200).send(result);
+      if (!isRejection(result)) {
+        res.status(200).send(result);
+      } else {
+        res.status(500).send(result);
+      }
     } catch (e) {
+      logger.logException('Could not upload file', e, { req });
       res.status(500).send(e);
     }
   };


### PR DESCRIPTION
## Description

This is a bugfix for failing to upload docx files.
The reason for failure was DB VARCHAR(64) which was too short for long docx mimetype.

Additionally to fix the fix was added where now the backend will return the appropriate HTTP status code 500 in case file upload fails

## How Has This Been Tested

unit tests

## Fixes

SWAP-1230

## Changes


## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/108

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
