### PR TITLE
Cleanup incomplete samples

### DIFF
--- a/db_patches/0069_AddProposalIdToSamples.sql
+++ b/db_patches/0069_AddProposalIdToSamples.sql
@@ -1,7 +1,7 @@
 DO
 $$
 BEGIN
-  IF register_patch('AddProposalIdToSamples.sql', 'Peter Asztalos', 'Add proposal events table to keep track of all fired events on a proposal.', '2020-10-22') THEN
+  IF register_patch('AddProposalIdToSamples.sql', 'jekabskarklins', 'Adding columns proposal_id and question_id to samples', '2020-10-22') THEN
     BEGIN
 
     ALTER TABLE "samples" ADD "proposal_id" INT DEFAULT NULL;

--- a/db_patches/0073_CleanupIncompleteSanples.sql
+++ b/db_patches/0073_CleanupIncompleteSanples.sql
@@ -1,0 +1,16 @@
+DO
+$$
+BEGIN
+	IF register_patch('CleanupIncompleteSanples.sql', 'jekabskarklins', 'Clean up incomplete samples and make proposal_id, question_id required', '2020-11-26') THEN
+        
+
+                DELETE FROM samples WHERE proposal_id is NULL OR question_id IS NULL;
+                
+                ALTER TABLE samples ALTER COLUMN proposal_id SET NOT NULL;
+                ALTER TABLE samples ALTER COLUMN question_id SET NOT NULL;
+
+
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

Fixes broken samples on the test server, and adds DB constraints

## Motivation and Context

Some samples have no proposal_id, these are samples that haven't been completed and added to the proposal, therefore they ought to be deleted

## How Has This Been Tested

- [x] Manual testing

## Fixes

N/A

## Changes

Added db script

## Depends on

N/A


## Tests included/Docs Updated?


- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
