### PR TITLE
SWAP-903 #resolve and keeping sep_id when removing roles fixed

### DIFF
--- a/src/datasources/SEPDataSource.ts
+++ b/src/datasources/SEPDataSource.ts
@@ -3,6 +3,7 @@ import { Role } from '../models/Role';
 import { SEP, SEPAssignment, SEPMember, SEPProposal } from '../models/SEP';
 import { User } from '../models/User';
 import { AddSEPMembersRole } from '../resolvers/mutations/AddSEPMembersRoleMutation';
+import { UpdateMemberSEPArgs } from '../resolvers/mutations/AssignMembersToSEP';
 
 export interface SEPDataSource {
   isMemberOfSEP(agent: User | null, sepId: number): Promise<boolean>;
@@ -41,11 +42,7 @@ export interface SEPDataSource {
   getMembers(sepId: number): Promise<SEPMember[]>;
   getSEPUserRoles(id: number, sepId: number): Promise<Role[]>;
   addSEPMembersRole(args: AddSEPMembersRole): Promise<SEP>;
-  removeSEPMemberRole(
-    memberId: number,
-    sepId: number,
-    roleId: number
-  ): Promise<SEP>;
+  removeSEPMemberRole(args: UpdateMemberSEPArgs): Promise<SEP>;
   assignProposal(proposalId: number, sepId: number): Promise<ProposalIds>;
   removeMemberFromSepProposal(
     proposalId: number,

--- a/src/datasources/mockups/SEPDataSource.ts
+++ b/src/datasources/mockups/SEPDataSource.ts
@@ -2,6 +2,7 @@ import { ProposalIds } from '../../models/Proposal';
 import { SEP, SEPAssignment, SEPMember, SEPProposal } from '../../models/SEP';
 import { User } from '../../models/User';
 import { AddSEPMembersRole } from '../../resolvers/mutations/AddSEPMembersRoleMutation';
+import { UpdateMemberSEPArgs } from '../../resolvers/mutations/AssignMembersToSEP';
 import { SEPDataSource } from '../SEPDataSource';
 
 export const dummySEP = new SEP(
@@ -184,14 +185,14 @@ export class SEPDataSourceMock implements SEPDataSource {
     throw new Error(`SEP not found ${args.SEPID}`);
   }
 
-  async removeSEPMemberRole(memberId: number, sepId: number, roleId: number) {
-    const sep = dummySEPs.find(element => element.id === sepId);
+  async removeSEPMemberRole(args: UpdateMemberSEPArgs) {
+    const sep = dummySEPs.find(element => element.id === args.sepId);
 
     if (sep) {
       return sep;
     }
 
-    throw new Error(`SEP not found ${sepId}`);
+    throw new Error(`SEP not found ${args.sepId}`);
   }
 
   async assignProposal(proposalId: number, sepId: number) {

--- a/src/datasources/postgres/UserDataSource.ts
+++ b/src/datasources/postgres/UserDataSource.ts
@@ -13,6 +13,7 @@ import {
   createUserObject,
   createBasicUserObject,
   RoleRecord,
+  RoleUserRecord,
 } from './records';
 
 export default class PostgresUserDataSource implements UserDataSource {
@@ -185,11 +186,21 @@ export default class PostgresUserDataSource implements UserDataSource {
         .from('role_user')
         .where('user_id', id)
         .del()
+        .returning('*')
         .transacting(trx)
-        .then(() => {
+        .then((data: RoleUserRecord[]) => {
           return BluePromise.map(roles, (role_id: number) => {
+            // NOTE: If some removed roles have had sep_id we need to keep that info.
+            const foundRoleSepId = data.find(
+              roleItem => roleItem.role_id === role_id
+            )?.sep_id;
+
             return database
-              .insert({ user_id: id, role_id: role_id })
+              .insert({
+                user_id: id,
+                role_id: role_id,
+                sep_id: foundRoleSepId,
+              })
               .into('role_user')
               .transacting(trx);
           });

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -282,7 +282,7 @@ export interface SEPAssignmentRecord {
   readonly email_sent: boolean;
 }
 
-export interface SEPMemberRecord {
+export interface RoleUserRecord {
   readonly role_user_id: number;
   readonly role_id: number;
   readonly user_id: number;

--- a/src/mutations/SEPMutations.spec.ts
+++ b/src/mutations/SEPMutations.spec.ts
@@ -152,6 +152,7 @@ describe('Test SEPMutations', () => {
       {
         memberId: 1,
         sepId: 1,
+        roleId: UserRole.SEP_CHAIR,
       }
     )) as Rejection;
 
@@ -163,6 +164,7 @@ describe('Test SEPMutations', () => {
       SEPMutationsInstance.removeMemberFromSEP(dummyUserOfficerWithRole, {
         memberId: 1,
         sepId: 1,
+        roleId: UserRole.SEP_CHAIR,
       })
     ).resolves.toStrictEqual(dummySEP);
   });

--- a/src/mutations/SEPMutations.ts
+++ b/src/mutations/SEPMutations.ts
@@ -94,20 +94,22 @@ export default class SEPMutations {
     agent: UserWithRole | null,
     args: AddSEPMembersRoleArgs
   ): Promise<SEP | Rejection> {
-    const [existingChairOrSecretary] = (
-      await this.dataSource.getMembers(args.addSEPMembersRole.SEPID)
-    ).filter(
+    const allSEPMembers = await this.dataSource.getMembers(
+      args.addSEPMembersRole.SEPID
+    );
+
+    const [existingChairOrSecretary] = allSEPMembers.filter(
       member =>
         member.roleId === args.addSEPMembersRole.roleID &&
         member.sepId === args.addSEPMembersRole.SEPID
     );
 
     if (existingChairOrSecretary) {
-      await this.dataSource.removeSEPMemberRole(
-        existingChairOrSecretary.userId,
-        existingChairOrSecretary.sepId,
-        existingChairOrSecretary.roleId
-      );
+      await this.dataSource.removeSEPMemberRole({
+        memberId: existingChairOrSecretary.userId,
+        sepId: existingChairOrSecretary.sepId,
+        roleId: existingChairOrSecretary.roleId,
+      });
     }
 
     return this.dataSource
@@ -177,7 +179,7 @@ export default class SEPMutations {
     }
 
     return this.dataSource
-      .removeSEPMemberRole(args.memberId, args.sepId, UserRole.SEP_REVIEWER)
+      .removeSEPMemberRole(args)
       .then(result => result)
       .catch(err => {
         logger.logException(

--- a/src/resolvers/mutations/AssignMembersToSEP.ts
+++ b/src/resolvers/mutations/AssignMembersToSEP.ts
@@ -9,6 +9,7 @@ import {
 } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
+import { UserRole } from '../../models/User';
 import { SEPResponseWrap } from '../types/CommonWrappers';
 import { wrapResponse } from '../wrapResponse';
 import { AddSEPMembersRoleArgs } from './AddSEPMembersRoleMutation';
@@ -20,6 +21,9 @@ export class UpdateMemberSEPArgs {
 
   @Field(() => Int)
   public sepId: number;
+
+  @Field(() => UserRole)
+  public roleId: UserRole;
 }
 
 @ArgsType()


### PR DESCRIPTION
## Description

Being able to remove SEP_Chair or SEP_Secretary and fixing of a found bug in reassigning roles from people settings page.

## Motivation and Context

As a user officer you should be able to remove SEP_chair or SEP_secretary from SEP. Also when adding new role to a user it was removing some important information about sep_id if some role is attached to a SEP.

## How Has This Been Tested

E2E tests on the frontend

## Fixes

https://jira.esss.lu.se/browse/SWAP-903

## Changes

Changes are mainly on the logic layer and fixing some types.

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
