### PR TITLE
SWAP-1188 As a user officer I should be able to verify users

### DIFF
--- a/db_patches/0000_init.sql
+++ b/db_patches/0000_init.sql
@@ -452,6 +452,55 @@ INSERT INTO users (
 
     INSERT INTO role_user (role_id, user_id) VALUES (1, 4);
 
+    -- this user is used for testing manual email verification and to remove the placeholder flag
+    INSERT INTO users (
+                      user_title, 
+                      firstname, 
+                      middlename, 
+                      lastname, 
+                      username, 
+                      password,
+                      preferredname,
+                      orcid,
+                      orcid_refreshToken,
+                      gender,
+                      nationality,
+                      birthdate,
+                      organisation,
+                      department,
+                      organisation_address,
+                      position,
+                      email,
+                      email_verified,
+                      telephone,
+                      telephone_alt
+                      ) 
+    VALUES 
+                    (
+                      'Mr.', 
+                      'Unverified email',
+                      '', 
+                      'Placeholder', 
+                      'testuser3', 
+                      '$2a$10$1svMW3/FwE5G1BpE7/CPW.aMyEymEBeWK4tSTtABbsoo/KaSQ.vwm',
+                      '',
+                      '123123123',
+                      '581459604',
+                      'male',
+                      'Danish',
+                      '2000-04-02',
+                      'Roberts, Reilly and Gutkowski',
+                      'IT deparment',
+                      'Denmark, Carlton Road, 2100 Riverside Avenue',
+                      'Management',
+                      'unverified-user@example.com',
+                      false,
+                      '(288) 221-4533',
+                      '(370) 555-4432'
+                      );
+
+    INSERT INTO role_user (role_id, user_id) VALUES (1, 5);
+
 
     INSERT INTO call(
               call_short_code 

--- a/db_patches/0013_AlterUsersEmailInvite.sql
+++ b/db_patches/0013_AlterUsersEmailInvite.sql
@@ -8,6 +8,7 @@ BEGIN
 
 		ALTER TABLE users ADD COLUMN placeholder BOOLEAN DEFAULT FALSE;
 
+		UPDATE users SET placeholder = true WHERE email = 'unverified-user@example.com';
 
 
     END;

--- a/src/datasources/UserDataSource.ts
+++ b/src/datasources/UserDataSource.ts
@@ -55,7 +55,8 @@ export interface UserDataSource {
   setUserRoles(id: number, roles: number[]): Promise<void>;
   setUserPassword(id: number, password: string): Promise<BasicUserDetails>;
   getPasswordByUsername(username: string): Promise<string | null>;
-  setUserEmailVerified(id: number): Promise<void>;
+  setUserEmailVerified(id: number): Promise<User | null>;
+  setUserNotPlaceholder(id: number): Promise<User | null>;
   checkScientistToProposal(
     userId: number,
     proposalId: number

--- a/src/datasources/mockups/UserDataSource.ts
+++ b/src/datasources/mockups/UserDataSource.ts
@@ -182,8 +182,12 @@ export class UserDataSourceMock implements UserDataSource {
   async getPasswordByEmail(email: string): Promise<string> {
     return '$2a$10$1svMW3/FwE5G1BpE7/CPW.aMyEymEBeWK4tSTtABbsoo/KaSQ.vwm';
   }
-  async setUserEmailVerified(id: number): Promise<void> {
+  async setUserEmailVerified(id: number): Promise<User | null> {
+    return null;
     // Do something here or remove the function.
+  }
+  async setUserNotPlaceholder(id: number): Promise<User | null> {
+    return null;
   }
   async setUserPassword(
     id: number,

--- a/src/datasources/postgres/UserDataSource.ts
+++ b/src/datasources/postgres/UserDataSource.ts
@@ -390,14 +390,31 @@ export default class PostgresUserDataSource implements UserDataSource {
         };
       });
   }
-  async setUserEmailVerified(id: number): Promise<void> {
-    return database
+
+  async setUserEmailVerified(id: number): Promise<User | null> {
+    const [userRecord]: [UserRecord] = await database
       .update({
         email_verified: true,
       })
       .from('users')
-      .where('user_id', id);
+      .where('user_id', id)
+      .returning('*');
+
+    return userRecord ? createUserObject(userRecord) : null;
   }
+
+  async setUserNotPlaceholder(id: number): Promise<User | null> {
+    const [userRecord]: [UserRecord] = await database
+      .update({
+        placeholder: false,
+      })
+      .from('users')
+      .where('user_id', id)
+      .returning('*');
+
+    return userRecord ? createUserObject(userRecord) : null;
+  }
+
   async getProposalUsersFull(proposalId: number): Promise<User[]> {
     return database
       .select()

--- a/src/mutations/UserMutations.ts
+++ b/src/mutations/UserMutations.ts
@@ -545,4 +545,20 @@ export default class UserMutations {
       return rejection('INTERNAL_ERROR');
     }
   }
+
+  @Authorized([Roles.USER_OFFICER])
+  setUserEmailVerified(
+    _: UserWithRole | null,
+    id: number
+  ): Promise<User | null> {
+    return this.dataSource.setUserEmailVerified(id);
+  }
+
+  @Authorized([Roles.USER_OFFICER])
+  setUserNotPlaceholder(
+    _: UserWithRole | null,
+    id: number
+  ): Promise<User | null> {
+    return this.dataSource.setUserNotPlaceholder(id);
+  }
 }

--- a/src/resolvers/mutations/UpdateUserMutation.ts
+++ b/src/resolvers/mutations/UpdateUserMutation.ts
@@ -6,6 +6,7 @@ import {
   Int,
   Mutation,
   Resolver,
+  Arg,
 } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
@@ -101,6 +102,28 @@ export class UpdateUserMutation {
   ) {
     return wrapResponse(
       context.mutations.user.updateRoles(context.user, args),
+      UserResponseWrap
+    );
+  }
+
+  @Mutation(() => UserResponseWrap)
+  setUserEmailVerified(
+    @Arg('id', () => Int) id: number,
+    @Ctx() context: ResolverContext
+  ) {
+    return wrapResponse(
+      context.mutations.user.setUserEmailVerified(context.user, id),
+      UserResponseWrap
+    );
+  }
+
+  @Mutation(() => UserResponseWrap)
+  setUserNotPlaceholder(
+    @Arg('id', () => Int) id: number,
+    @Ctx() context: ResolverContext
+  ) {
+    return wrapResponse(
+      context.mutations.user.setUserNotPlaceholder(context.user, id),
       UserResponseWrap
     );
   }


### PR DESCRIPTION
## Description

This PR adds support to manually verify email and remove the placeholder flag from a user account.
<!--- Describe your changes in detail -->

## Motivation and Context

As it is now, it is not possible to do this manually as a User Officer.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e test on the FE
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1188
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- API endpoints added for the manual updates
- e2e tests related seeds added
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/138
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
