### PR TITLE
Fix missing downloads directory

### DIFF
--- a/src/mutations/FileMutations.ts
+++ b/src/mutations/FileMutations.ts
@@ -1,3 +1,5 @@
+import { existsSync, mkdirSync } from 'fs';
+
 import { logger } from '@esss-swap/duo-logger';
 
 import { FileDataSource } from '../datasources/IFileDataSource';
@@ -24,7 +26,11 @@ export default class FileMutations {
   }
 
   async prepare(fileId: string): Promise<string | Rejection> {
-    const filePath = `downloads/${fileId}`;
+    const DOWNLOADS_DIR = 'downloads';
+    if (!existsSync(DOWNLOADS_DIR)) {
+      mkdirSync(DOWNLOADS_DIR);
+    }
+    const filePath = `${DOWNLOADS_DIR}/${fileId}`;
 
     return this.dataSource
       .prepare(fileId, filePath)


### PR DESCRIPTION
## Description

This fixes broken downloads.

The construction of the downloads folder was removed from the dockerfile, presumably by accident.

To prevent this from happening in the future the code itself will now create the folder if it does not exist.