### PR TITLE
fix wrong table name

### DIFF
--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -248,7 +248,7 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
             .join('|');
 
           query.whereRaw(
-            `proposal_table_view.short_code similar to '%(${filteredAndPreparedShortCodes})%'`
+            `proposals.short_code similar to '%(${filteredAndPreparedShortCodes})%'`
           );
         }
 
@@ -313,7 +313,7 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
             .join('|');
 
           query.whereRaw(
-            `proposal_table_view.short_code similar to '%(${filteredAndPreparedShortCodes})%'`
+            `proposals.short_code similar to '%(${filteredAndPreparedShortCodes})%'`
           );
         }
 


### PR DESCRIPTION
## Description

This is a fix for wrong table name when querying proposals by shortCode
