### PR TITLE
SEP Bugfix: let SEP Chair/Secretary access reviews

### DIFF
--- a/src/queries/ReviewQueries.ts
+++ b/src/queries/ReviewQueries.ts
@@ -33,11 +33,18 @@ export default class ReviewQueries {
     }
   }
 
-  @Authorized([Roles.USER_OFFICER])
+  @Authorized([Roles.USER_OFFICER, Roles.SEP_CHAIR, Roles.SEP_SECRETARY])
   async reviewsForProposal(
     agent: UserWithRole | null,
     proposalId: number
   ): Promise<Review[] | null> {
+    if (
+      !(await this.userAuth.isUserOfficer(agent)) &&
+      !(await this.userAuth.isChairOrSecretaryOfProposal(agent!.id, proposalId))
+    ) {
+      return null;
+    }
+
     return this.dataSource.getProposalReviews(proposalId);
   }
 
@@ -48,7 +55,8 @@ export default class ReviewQueries {
   ): Promise<TechnicalReview | null> {
     if (
       (await this.userAuth.isUserOfficer(user)) ||
-      (await this.userAuth.isScientistToProposal(user, proposalID))
+      (await this.userAuth.isScientistToProposal(user, proposalID)) ||
+      (await this.userAuth.isChairOrSecretaryOfProposal(user!.id, proposalID))
     ) {
       return this.dataSource.getTechnicalReview(proposalID);
     } else if (await this.userAuth.isReviewerOfProposal(user, proposalID)) {

--- a/src/resolvers/types/Review.ts
+++ b/src/resolvers/types/Review.ts
@@ -11,7 +11,7 @@ import {
 import { ResolverContext } from '../../context';
 import { Review as ReviewOrigin, ReviewStatus } from '../../models/Review';
 import { Proposal } from '../types/Proposal';
-import { User } from '../types/User';
+import { BasicUserDetails } from './BasicUserDetails';
 
 @ObjectType()
 export class Review implements Partial<ReviewOrigin> {
@@ -38,12 +38,12 @@ export class Review implements Partial<ReviewOrigin> {
 
 @Resolver(() => Review)
 export class ReviewResolver {
-  @FieldResolver(() => User, { nullable: true })
+  @FieldResolver(() => BasicUserDetails, { nullable: true })
   async reviewer(
     @Root() review: Review,
     @Ctx() context: ResolverContext
-  ): Promise<User | null> {
-    return context.queries.user.get(context.user, review.userID);
+  ): Promise<BasicUserDetails | null> {
+    return context.queries.user.getBasic(context.user, review.userID);
   }
 
   @FieldResolver(() => Proposal, { nullable: true })


### PR DESCRIPTION
## Description

This PR fixes the empty "External reviews" table on the final ranking form.
<!--- Describe your changes in detail -->

## Motivation and Context

Right now it's not visible because of permission issues.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e test added
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

- required permission to access proposal reviewers list
- model used to query the reviewer's data
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/207
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
