### PR TITLE
Use a no-op function in development for sending email.

### DIFF
--- a/src/eventHandlers/email.ts
+++ b/src/eventHandlers/email.ts
@@ -12,6 +12,12 @@ const options = {
   endpoint: 'https://api.eu.sparkpost.com:443',
 };
 const client = new SparkPost(process.env.SPARKPOST_TOKEN, options);
+const isDevEnv = process.env.NODE_ENV === 'development';
+
+// in dev env don't try to send email
+if (isDevEnv) {
+  client.transmissions.send = async (...args: any[]): Promise<any> => 'no-op';
+}
 
 export default function createHandler(userDataSource: UserDataSource) {
   // Handler to send email to proposers in accepted proposal
@@ -147,7 +153,7 @@ export default function createHandler(userDataSource: UserDataSource) {
       }
 
       case Event.USER_CREATED: {
-        if (process.env.NODE_ENV === 'development') {
+        if (isDevEnv) {
           await userDataSource.setUserEmailVerified(
             event.userlinkresponse.user.id
           );


### PR DESCRIPTION
This will remove the "errors" from the logs, also helps with following what email should have been sent
