### PR TITLE
Swap 1346/7 technical review small fixes

### DIFF
--- a/db_patches/0080_AddTechnicalReviewSubmittedFlag.sql
+++ b/db_patches/0080_AddTechnicalReviewSubmittedFlag.sql
@@ -1,0 +1,11 @@
+DO
+$$
+BEGIN
+	IF register_patch('AddTechnicalReviewSubmittedFlag.sql', 'martintrajanovski', 'Add submitted flag in technical_review', '2020-02-10') THEN
+	BEGIN
+      ALTER TABLE technical_review ADD COLUMN submitted BOOLEAN DEFAULT FALSE;
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/datasources/ReviewDataSource.ts
+++ b/src/datasources/ReviewDataSource.ts
@@ -1,7 +1,7 @@
 import { Review } from '../models/Review';
 import { TechnicalReview } from '../models/TechnicalReview';
 import { AddReviewArgs } from '../resolvers/mutations/AddReviewMutation';
-import { AddTechnicalReviewArgs } from '../resolvers/mutations/AddTechnicalReviewMutation';
+import { AddTechnicalReviewInput } from '../resolvers/mutations/AddTechnicalReviewMutation';
 import { AddUserForReviewArgs } from '../resolvers/mutations/AddUserForReviewMutation';
 
 export interface ReviewDataSource {
@@ -16,7 +16,10 @@ export interface ReviewDataSource {
     proposalId: number,
     userId: number
   ): Promise<Review | null>;
-  setTechnicalReview(args: AddTechnicalReviewArgs): Promise<TechnicalReview>;
+  setTechnicalReview(
+    args: AddTechnicalReviewInput,
+    submitted?: boolean
+  ): Promise<TechnicalReview>;
   getTechnicalReview(proposalID: number): Promise<TechnicalReview | null>;
   addUserForReview(args: AddUserForReviewArgs): Promise<Review>;
 }

--- a/src/datasources/mockups/ReviewDataSource.ts
+++ b/src/datasources/mockups/ReviewDataSource.ts
@@ -1,7 +1,7 @@
 import { Review } from '../../models/Review';
 import { TechnicalReview } from '../../models/TechnicalReview';
 import { AddReviewArgs } from '../../resolvers/mutations/AddReviewMutation';
-import { AddTechnicalReviewArgs } from '../../resolvers/mutations/AddTechnicalReviewMutation';
+import { AddTechnicalReviewInput } from '../../resolvers/mutations/AddTechnicalReviewMutation';
 import { AddUserForReviewArgs } from '../../resolvers/mutations/AddUserForReviewMutation';
 import { ReviewDataSource } from '../ReviewDataSource';
 
@@ -13,7 +13,10 @@ export class ReviewDataSourceMock implements ReviewDataSource {
   getTechnicalReview(proposalID: number): Promise<TechnicalReview | null> {
     throw new Error('Method not implemented.');
   }
-  setTechnicalReview(args: AddTechnicalReviewArgs): Promise<TechnicalReview> {
+  setTechnicalReview(
+    args: AddTechnicalReviewInput,
+    submitted: boolean = false
+  ): Promise<TechnicalReview> {
     throw new Error('Method not implemented.');
   }
   async addUserForReview(args: AddUserForReviewArgs): Promise<Review> {

--- a/src/datasources/postgres/ReviewDataSource.ts
+++ b/src/datasources/postgres/ReviewDataSource.ts
@@ -39,22 +39,28 @@ export default class PostgresReviewDataSource implements ReviewDataSource {
   ): Promise<TechnicalReview> {
     const { proposalID, comment, publicComment, timeAllocation, status } = args;
 
-    if (await this.getTechnicalReview(proposalID)) {
-      return database
-        .update({
-          proposal_id: proposalID,
-          comment,
-          public_comment: publicComment,
-          time_allocation: timeAllocation,
-          status,
-          submitted,
-        })
-        .from('technical_review')
-        .where('proposal_id', proposalID)
-        .returning('*')
-        .then((records: TechnicalReviewRecord[]) =>
-          this.createTechnicalReviewObject(records[0])
-        );
+    const technicalReview = await this.getTechnicalReview(proposalID);
+
+    if (technicalReview) {
+      if (!technicalReview.submitted) {
+        return database
+          .update({
+            proposal_id: proposalID,
+            comment,
+            public_comment: publicComment,
+            time_allocation: timeAllocation,
+            status,
+            submitted,
+          })
+          .from('technical_review')
+          .where('proposal_id', proposalID)
+          .returning('*')
+          .then((records: TechnicalReviewRecord[]) =>
+            this.createTechnicalReviewObject(records[0])
+          );
+      } else {
+        throw new Error('Technical review already submitted');
+      }
     }
 
     return database

--- a/src/datasources/postgres/ReviewDataSource.ts
+++ b/src/datasources/postgres/ReviewDataSource.ts
@@ -2,7 +2,7 @@
 import { Review, ReviewStatus } from '../../models/Review';
 import { TechnicalReview } from '../../models/TechnicalReview';
 import { AddReviewArgs } from '../../resolvers/mutations/AddReviewMutation';
-import { AddTechnicalReviewArgs } from '../../resolvers/mutations/AddTechnicalReviewMutation';
+import { AddTechnicalReviewInput } from '../../resolvers/mutations/AddTechnicalReviewMutation';
 import { AddUserForReviewArgs } from '../../resolvers/mutations/AddUserForReviewMutation';
 import { ReviewDataSource } from '../ReviewDataSource';
 import database from './database';
@@ -28,12 +28,14 @@ export default class PostgresReviewDataSource implements ReviewDataSource {
       technicalReview.comment,
       technicalReview.public_comment,
       technicalReview.time_allocation,
-      technicalReview.status
+      technicalReview.status,
+      technicalReview.submitted
     );
   }
 
   async setTechnicalReview(
-    args: AddTechnicalReviewArgs
+    args: AddTechnicalReviewInput,
+    submitted: boolean = false
   ): Promise<TechnicalReview> {
     const { proposalID, comment, publicComment, timeAllocation, status } = args;
 
@@ -45,6 +47,7 @@ export default class PostgresReviewDataSource implements ReviewDataSource {
           public_comment: publicComment,
           time_allocation: timeAllocation,
           status,
+          submitted,
         })
         .from('technical_review')
         .where('proposal_id', proposalID)
@@ -61,6 +64,7 @@ export default class PostgresReviewDataSource implements ReviewDataSource {
         public_comment: publicComment,
         time_allocation: timeAllocation,
         status,
+        submitted,
       })
       .returning('*')
       .into('technical_review')

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -207,6 +207,7 @@ export interface TechnicalReviewRecord {
   readonly public_comment: string;
   readonly time_allocation: number;
   readonly status: number;
+  readonly submitted: boolean;
 }
 
 export interface CallRecord {

--- a/src/models/TechnicalReview.ts
+++ b/src/models/TechnicalReview.ts
@@ -5,7 +5,8 @@ export class TechnicalReview {
     public comment: string,
     public publicComment: string,
     public timeAllocation: number,
-    public status: number
+    public status: number,
+    public submitted: boolean
   ) {}
 }
 

--- a/src/mutations/ReviewMutations.ts
+++ b/src/mutations/ReviewMutations.ts
@@ -15,8 +15,9 @@ import { TechnicalReview } from '../models/TechnicalReview';
 import { UserWithRole } from '../models/User';
 import { rejection, Rejection } from '../rejection';
 import { AddReviewArgs } from '../resolvers/mutations/AddReviewMutation';
-import { AddTechnicalReviewArgs } from '../resolvers/mutations/AddTechnicalReviewMutation';
+import { AddTechnicalReviewInput } from '../resolvers/mutations/AddTechnicalReviewMutation';
 import { AddUserForReviewArgs } from '../resolvers/mutations/AddUserForReviewMutation';
+import { SubmitTechnicalReviewInput } from '../resolvers/mutations/SubmitTechnicalReviewMutation';
 import { UserAuthorization } from '../utils/UserAuthorization';
 
 export default class ReviewMutations {
@@ -78,7 +79,7 @@ export default class ReviewMutations {
   @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST])
   async setTechnicalReview(
     agent: UserWithRole | null,
-    args: AddTechnicalReviewArgs
+    args: AddTechnicalReviewInput | SubmitTechnicalReviewInput
   ): Promise<TechnicalReview | Rejection> {
     if (
       !(
@@ -91,8 +92,10 @@ export default class ReviewMutations {
       return rejection('INSUFFICIENT_PERMISSIONS');
     }
 
+    const shouldSubmitTechnicalReview = 'submitted' in args && args.submitted;
+
     return this.dataSource
-      .setTechnicalReview(args)
+      .setTechnicalReview(args, shouldSubmitTechnicalReview)
       .then(review => review)
       .catch(err => {
         logger.logException('Could not set technicalReview', err, {

--- a/src/resolvers/mutations/SubmitTechnicalReviewMutation.ts
+++ b/src/resolvers/mutations/SubmitTechnicalReviewMutation.ts
@@ -1,7 +1,5 @@
 import {
   Arg,
-  Args,
-  ArgsType,
   Ctx,
   Field,
   InputType,
@@ -15,8 +13,9 @@ import { TechnicalReviewStatus } from '../../models/TechnicalReview';
 import { TechnicalReviewResponseWrap } from '../types/CommonWrappers';
 import { TechnicalReview } from '../types/TechnicalReview';
 import { wrapResponse } from '../wrapResponse';
+
 @InputType()
-export class AddTechnicalReviewInput implements Partial<TechnicalReview> {
+export class SubmitTechnicalReviewInput implements Partial<TechnicalReview> {
   @Field(() => Int)
   public proposalID: number;
 
@@ -31,20 +30,23 @@ export class AddTechnicalReviewInput implements Partial<TechnicalReview> {
 
   @Field(() => TechnicalReviewStatus, { nullable: true })
   public status: TechnicalReviewStatus;
+
+  @Field(() => Boolean)
+  public submitted: boolean;
 }
 
 @Resolver()
-export class AddTechnicalReviewMutation {
+export class SubmitTechnicalReviewMutation {
   @Mutation(() => TechnicalReviewResponseWrap)
-  addTechnicalReview(
-    @Arg('addTechnicalReviewInput')
-    addTechnicalReviewInput: AddTechnicalReviewInput,
+  submitTechnicalReview(
+    @Arg('submitTechnicalReviewInput')
+    submitTechnicalReviewInput: SubmitTechnicalReviewInput,
     @Ctx() context: ResolverContext
   ) {
     return wrapResponse<TechnicalReview>(
       context.mutations.review.setTechnicalReview(
         context.user,
-        addTechnicalReviewInput
+        submitTechnicalReviewInput
       ),
       TechnicalReviewResponseWrap
     );

--- a/src/resolvers/types/TechnicalReview.ts
+++ b/src/resolvers/types/TechnicalReview.ts
@@ -34,6 +34,9 @@ export class TechnicalReview implements Partial<TechnicalReviewOrigin> {
 
   @Field(() => TechnicalReviewStatus, { nullable: true })
   public status: TechnicalReviewStatus;
+
+  @Field(() => Boolean)
+  public submitted: boolean;
 }
 
 @Resolver(() => TechnicalReview)


### PR DESCRIPTION
## Description

Add ability to submit technical review and prevent updates if submitted.

## Motivation and Context

Previously there was no possibility to submit a technical review only update and we need a way to submit and lock it.

## How Has This Been Tested

e2e tests on the frontend

## Fixes

https://jira.esss.lu.se/browse/SWAP-1347

## Changes

Adding the field in the database and supporting the functionality to use it.


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
