### PR TITLE
Swap 1381 call proposal count

### DIFF
--- a/src/datasources/ProposalDataSource.ts
+++ b/src/datasources/ProposalDataSource.ts
@@ -41,4 +41,5 @@ export interface ProposalDataSource {
     event: Event,
     proposalId: number
   ): Promise<ProposalEventsRecord | null>;
+  getCount(callId: number): Promise<number>;
 }

--- a/src/datasources/mockups/ProposalDataSource.ts
+++ b/src/datasources/mockups/ProposalDataSource.ts
@@ -173,4 +173,8 @@ export class ProposalDataSourceMock implements ProposalDataSource {
       proposal_notified: false,
     };
   }
+
+  async getCount(callId: number): Promise<number> {
+    return 1;
+  }
 }

--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -372,4 +372,14 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
       return null;
     }
   }
+
+  async getCount(callId: number): Promise<number> {
+    return database('proposals')
+      .count('call_id')
+      .where('call_id', callId)
+      .first()
+      .then((result: { count?: string | undefined } | undefined) => {
+        return parseInt(result?.count || '0');
+      });
+  }
 }

--- a/src/resolvers/types/Call.ts
+++ b/src/resolvers/types/Call.ts
@@ -81,6 +81,11 @@ export class CallInstrumentsResolver {
       call.proposalWorkflowId
     );
   }
+
+  @FieldResolver(() => Int, { nullable: true })
+  async proposalCount(@Root() call: Call, @Ctx() context: ResolverContext) {
+    return context.queries.proposal.dataSource.getCount(call.id);
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/resolvers/types/Call.ts
+++ b/src/resolvers/types/Call.ts
@@ -82,7 +82,7 @@ export class CallInstrumentsResolver {
     );
   }
 
-  @FieldResolver(() => Int, { nullable: true })
+  @FieldResolver(() => Int)
   async proposalCount(@Root() call: Call, @Ctx() context: ResolverContext) {
     return context.queries.proposal.dataSource.getCount(call.id);
   }


### PR DESCRIPTION
## Description

Adding `proposalCount` resolver on the call.

## Motivation and Context

To be able to see how many proposals are on the call.

## How Has This Been Tested

e2e tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1381


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
