### PR TITLE
Hot fix for SEP assigment

### DIFF
--- a/src/mutations/SEPMutations.ts
+++ b/src/mutations/SEPMutations.ts
@@ -193,7 +193,7 @@ export default class SEPMutations {
     args: AssignProposalToSEPArgs
   ): Promise<ProposalIdsWithNextStatus | Rejection> {
     const SEP = await this.dataSource.getSEPByProposalId(args.proposalId);
-    if (SEP !== null) {
+    if (SEP) {
       if (
         isRejection(
           await this.removeProposalAssignment(agent, {

--- a/src/mutations/SEPMutations.ts
+++ b/src/mutations/SEPMutations.ts
@@ -18,7 +18,7 @@ import { ProposalIdsWithNextStatus } from '../models/Proposal';
 import { Roles } from '../models/Role';
 import { SEP } from '../models/SEP';
 import { UserWithRole, UserRole } from '../models/User';
-import { rejection, Rejection } from '../rejection';
+import { rejection, Rejection, isRejection } from '../rejection';
 import {
   UpdateMemberSEPArgs,
   AssignSepReviewersToProposalArgs,
@@ -192,6 +192,20 @@ export default class SEPMutations {
     agent: UserWithRole | null,
     args: AssignProposalToSEPArgs
   ): Promise<ProposalIdsWithNextStatus | Rejection> {
+    const SEP = await this.dataSource.getSEPByProposalId(args.proposalId);
+    if (SEP !== null) {
+      if (
+        isRejection(
+          await this.removeProposalAssignment(agent, {
+            proposalId: args.proposalId,
+            sepId: SEP.id,
+          })
+        )
+      ) {
+        return rejection('INTERNAL_ERROR');
+      }
+    }
+
     return this.dataSource
       .assignProposal(args.proposalId, args.sepId)
       .then(async result => {


### PR DESCRIPTION
## Description

At the moment a proposal can have multiple SEP's assigned to it, this will cause the proposal to appear multiple times in the list

## Motivation and Context

See above

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
