### PR TITLE
sep bugs fixed

### DIFF
--- a/src/datasources/postgres/SEPDataSource.ts
+++ b/src/datasources/postgres/SEPDataSource.ts
@@ -228,12 +228,6 @@ export default class PostgresSEPDataSource implements SEPDataSource {
       .join('proposals as p', {
         'p.proposal_id': 'sp.proposal_id',
       })
-      .join('proposal_statuses as ps', {
-        'p.status_id': 'ps.proposal_status_id',
-      })
-      .where(function() {
-        this.where('ps.name', 'ilike', 'SEP_%');
-      })
       .where('sp.sep_id', sepId)
       .where('sp.proposal_id', proposalId)
       .first();

--- a/src/mutations/SEPMutations.ts
+++ b/src/mutations/SEPMutations.ts
@@ -301,7 +301,7 @@ export default class SEPMutations {
     agent: UserWithRole | null,
     { sepId, proposalId, sepTimeAllocation = null }: UpdateSEPTimeAllocationArgs
   ) {
-    const isUserOfficer = await this.userAuth.isUserOfficer(agent);
+    const isUserOfficer = this.userAuth.isUserOfficer(agent);
     if (
       !isUserOfficer &&
       !(await this.userAuth.isChairOrSecretaryOfSEP(agent!.id, sepId))

--- a/src/resolvers/types/Proposal.ts
+++ b/src/resolvers/types/Proposal.ts
@@ -18,7 +18,7 @@ import {
 import { isRejection } from '../../rejection';
 import { BasicUserDetails } from './BasicUserDetails';
 import { Call } from './Call';
-import { Instrument } from './Instrument';
+import { Instrument, InstrumentWithAvailabilityTime } from './Instrument';
 import { ProposalStatus } from './ProposalStatus';
 import { Questionary } from './Questionary';
 import { Review } from './Review';

--- a/src/resolvers/types/Proposal.ts
+++ b/src/resolvers/types/Proposal.ts
@@ -18,7 +18,7 @@ import {
 import { isRejection } from '../../rejection';
 import { BasicUserDetails } from './BasicUserDetails';
 import { Call } from './Call';
-import { Instrument, InstrumentWithAvailabilityTime } from './Instrument';
+import { Instrument } from './Instrument';
 import { ProposalStatus } from './ProposalStatus';
 import { Questionary } from './Questionary';
 import { Review } from './Review';

--- a/src/resolvers/types/SEPProposal.ts
+++ b/src/resolvers/types/SEPProposal.ts
@@ -47,4 +47,14 @@ export class SEPUserResolver {
       proposalId: sepProposal.proposalId,
     });
   }
+
+  @FieldResolver(() => Boolean)
+  async instrumentSubmitted(
+    @Root() sepProposal: SEPProposal,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.queries.instrument.dataSource.isProposalInstrumentSubmitted(
+      sepProposal.proposalId
+    );
+  }
 }

--- a/src/utils/UserAuthorization.ts
+++ b/src/utils/UserAuthorization.ts
@@ -12,7 +12,7 @@ import { StfcUserDataSource } from '../datasources/stfc/StfcUserDataSource';
 import { UserDataSource } from '../datasources/UserDataSource';
 import { Proposal } from '../models/Proposal';
 import { Roles } from '../models/Role';
-import { User, UserRole, UserWithRole } from '../models/User';
+import { User, UserWithRole } from '../models/User';
 
 export class UserAuthorization {
   constructor(
@@ -21,7 +21,7 @@ export class UserAuthorization {
     private sepDataSource: SEPDataSource
   ) {}
 
-  async isUserOfficer(agent: UserWithRole | null) {
+  isUserOfficer(agent: UserWithRole | null) {
     if (agent == null) {
       return false;
     }
@@ -30,7 +30,7 @@ export class UserAuthorization {
   }
 
   // NOTE: This is not a good check if it is a user or not. It should do the same check as isUserOfficer.
-  async isUser(agent: User | null, id: number) {
+  isUser(agent: User | null, id: number) {
     if (agent == null) {
       return false;
     }
@@ -116,7 +116,7 @@ export class UserAuthorization {
     }
 
     return (
-      (await this.isUserOfficer(agent)) ||
+      this.isUserOfficer(agent) ||
       (await this.isMemberOfProposal(agent, proposal)) ||
       (await this.isReviewerOfProposal(agent, proposal.id)) ||
       (await this.isScientistToProposal(agent, proposal.id)) ||


### PR DESCRIPTION
## Description

This PR fixes two SEP related bugs:
- proposals not in SEP_ status weren't accessible in the final ranking form: fixed
- it's possible to have proposals that have their instrument submitted but this is not visible on the UI: fixed
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e test
- [x] manual test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

- return proposals in sep final ranking form regardless of their current status
- include the instrument-submitted flag for each proposal
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/246
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
