### PR TITLE
Allow only SEP Reviewers to become SEP Chair/Secretary

### DIFF
--- a/src/buildContext.ts
+++ b/src/buildContext.ts
@@ -102,7 +102,8 @@ const sepQueries = new SEPQueries(sepDataSource, userAuthorization);
 const sepMutations = new SEPMutations(
   sepDataSource,
   instrumentDataSource,
-  userAuthorization
+  userAuthorization,
+  userDataSource
 );
 
 const systemQueries = new SystemQueries(systemDataSource);

--- a/src/datasources/mockups/SEPDataSource.ts
+++ b/src/datasources/mockups/SEPDataSource.ts
@@ -1,3 +1,4 @@
+import { Event } from '../../events/event.enum';
 import { ProposalIdsWithNextStatus } from '../../models/Proposal';
 import { ProposalStatus } from '../../models/ProposalStatus';
 import { SEP, SEPAssignment, SEPReviewer, SEPProposal } from '../../models/SEP';

--- a/src/datasources/mockups/UserDataSource.ts
+++ b/src/datasources/mockups/UserDataSource.ts
@@ -254,6 +254,8 @@ export class UserDataSourceMock implements UserDataSource {
           shortCode: 'instrument_scientist',
         },
       ];
+    } else if (id === 1001) {
+      return [{ id: 2, shortCode: 'SEP_Reviewer', title: 'User' }];
     } else {
       return [{ id: 2, shortCode: 'user', title: 'User' }];
     }


### PR DESCRIPTION
## Description

This PR introduces some additional checks to User-to-SEP assignment: only users with SEP Reviewer role can become SEP Chair/Secretary (obviously by following the normal flow).
<!--- Describe your changes in detail -->

## Motivation and Context

Currently, any user can be selected.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] e2e testing
- [x] manual testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

- require users to have SEP Reviewer role to assign to SEP as a SEP Chair/Secretary
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/248
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
