### PR TITLE
Delete instrument-proposal connection when proposal is deleted

### DIFF
--- a/db_patches/0081_AlterInstrumentHasProposalTable.sql
+++ b/db_patches/0081_AlterInstrumentHasProposalTable.sql
@@ -1,0 +1,20 @@
+DO
+$$
+DECLARE 
+   t_row role_user%rowtype;
+BEGIN
+    IF register_patch('AlterInstrumentHasProposalTable.sql', 'Peter Asztalos', 'Alter instrument_has_proposal table so deleting a proposal will cascade delete', '2021-02-15') THEN
+
+      ALTER TABLE instrument_has_proposals DROP CONSTRAINT instrument_has_proposals_proposal_id_fkey;
+
+      ALTER TABLE instrument_has_proposals 
+        ADD CONSTRAINT instrument_has_proposals_proposal_id_fkey 
+            FOREIGN KEY (proposal_id)
+            REFERENCES proposals (proposal_id) 
+            ON UPDATE CASCADE 
+            ON DELETE CASCADE;
+
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

This PR changes the on delete action of `instrument_has_proposal`.`proposal_id` so when we delete a proposal we also delete the related instrument-proposal connection.
<!--- Describe your changes in detail -->


## How Has This Been Tested

- [x] manual test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
