### PR TITLE
SWAP-1410 #resolved

### DIFF
--- a/src/datasources/ProposalDataSource.ts
+++ b/src/datasources/ProposalDataSource.ts
@@ -47,4 +47,9 @@ export interface ProposalDataSource {
     callId: number,
     templateId: number
   ): Promise<Proposal>;
+  resetProposalEvents(
+    proposalId: number,
+    callId: number,
+    statusId: number
+  ): Promise<boolean>;
 }

--- a/src/datasources/mockups/ProposalDataSource.ts
+++ b/src/datasources/mockups/ProposalDataSource.ts
@@ -185,4 +185,12 @@ export class ProposalDataSourceMock implements ProposalDataSource {
   ): Promise<Proposal> {
     return dummyProposal;
   }
+
+  async resetProposalEvents(
+    proposalId: number,
+    callId: number,
+    statusId: number
+  ): Promise<boolean> {
+    return true;
+  }
 }

--- a/src/mutations/ProposalMutations.ts
+++ b/src/mutations/ProposalMutations.ts
@@ -287,6 +287,19 @@ export default class ProposalMutations {
       proposal.finalStatus = finalStatus;
     }
 
+    if (proposal.statusId !== statusId && statusId) {
+      /**
+       * NOTE: Reset proposal events that are coming after given status.
+       * For example if proposal had SEP_REVIEW status and we manually reset to FEASIBILITY_REVIEW then events like:
+       * proposal_feasible, proposal_feasibility_review_submitted and proposal_sep_selected should be reset to false in the proposal_events table
+       */
+      await this.proposalDataSource.resetProposalEvents(
+        proposal.id,
+        proposal.callId,
+        statusId
+      );
+    }
+
     if (statusId !== undefined) {
       proposal.statusId = statusId;
     }


### PR DESCRIPTION
## Description

Reset proposal events that are coming after given status. For example if proposal had SEP_REVIEW status and we manually reset to FEASIBILITY_REVIEW then events like: proposal_feasible, proposal_feasibility_review_submitted and proposal_sep_selected should be reset to false in the proposal_events table

## Motivation and Context

Previously if we manually reset proposal status the events were staying in the state they are nothing was changed there to reset them at the point where proposal is returned.

## How Has This Been Tested

manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1410

## Changes

Added new method for reseting proposal events inside proposal data source.


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
