### PR TITLE
Swap 1396 change status on multiple proposals

### DIFF
--- a/db_patches/0086_AddProposalStatusUpdatedEvent.sql
+++ b/db_patches/0086_AddProposalStatusUpdatedEvent.sql
@@ -1,0 +1,11 @@
+DO
+$$
+BEGIN
+	IF register_patch('AddProposalStatusUpdatedEvent.sql', 'martintrajanovski', 'Add proposal_status_updated event', '2021-03-19') THEN
+        BEGIN
+            ALTER TABLE proposal_events ADD COLUMN proposal_status_updated BOOLEAN DEFAULT FALSE;
+        END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/datasources/ProposalDataSource.ts
+++ b/src/datasources/ProposalDataSource.ts
@@ -1,5 +1,5 @@
 import { Event } from '../events/event.enum';
-import { Proposal } from '../models/Proposal';
+import { Proposal, ProposalIdsWithNextStatus } from '../models/Proposal';
 import { ProposalView } from '../models/ProposalView';
 import { ProposalsFilter } from './../resolvers/queries/ProposalsQuery';
 import { ProposalEventsRecord } from './postgres/records';
@@ -52,4 +52,8 @@ export interface ProposalDataSource {
     callId: number,
     statusId: number
   ): Promise<boolean>;
+  changeProposalsStatus(
+    statusId: number,
+    proposalIds: number[]
+  ): Promise<ProposalIdsWithNextStatus>;
 }

--- a/src/datasources/mockups/ProposalDataSource.ts
+++ b/src/datasources/mockups/ProposalDataSource.ts
@@ -1,6 +1,10 @@
 import 'reflect-metadata';
 import { Event } from '../../events/event.enum';
-import { Proposal, ProposalEndStatus } from '../../models/Proposal';
+import {
+  Proposal,
+  ProposalEndStatus,
+  ProposalIdsWithNextStatus,
+} from '../../models/Proposal';
 import { ProposalView } from '../../models/ProposalView';
 import { ProposalEventsRecord } from '../postgres/records';
 import { ProposalDataSource } from '../ProposalDataSource';
@@ -194,5 +198,12 @@ export class ProposalDataSourceMock implements ProposalDataSource {
     statusId: number
   ): Promise<boolean> {
     return true;
+  }
+
+  async changeProposalsStatus(
+    statusId: number,
+    proposalIds: number[]
+  ): Promise<ProposalIdsWithNextStatus> {
+    return { proposalIds: [1] };
   }
 }

--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -3,7 +3,7 @@ import BluePromise from 'bluebird';
 import { Transaction } from 'knex';
 
 import { Event } from '../../events/event.enum';
-import { Proposal } from '../../models/Proposal';
+import { Proposal, ProposalIdsWithNextStatus } from '../../models/Proposal';
 import { ProposalView } from '../../models/ProposalView';
 import { getQuestionDefinition } from '../../models/questionTypes/QuestionRegistry';
 import { ProposalDataSource } from '../ProposalDataSource';
@@ -558,5 +558,13 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     }
 
     return true;
+  }
+
+  async changeProposalsStatus(
+    statusId: number,
+    proposalIds: number[]
+  ): Promise<ProposalIdsWithNextStatus> {
+    // TODO: Finish this!
+    return { proposalIds: [1] };
   }
 }

--- a/src/eventHandlers/logging.ts
+++ b/src/eventHandlers/logging.ts
@@ -47,6 +47,7 @@ export default function createHandler(
           break;
         case Event.PROPOSAL_INSTRUMENT_SELECTED:
         case Event.PROPOSAL_SEP_SELECTED:
+        case Event.PROPOSAL_STATUS_UPDATED:
           event.proposalidswithnextstatus.proposalIds.forEach(
             async (proposalId) => {
               await eventLogsDataSource.set(

--- a/src/eventHandlers/proposalWorkflow.ts
+++ b/src/eventHandlers/proposalWorkflow.ts
@@ -57,6 +57,7 @@ export default function createHandler(
         break;
       case Event.PROPOSAL_INSTRUMENT_SELECTED:
       case Event.PROPOSAL_SEP_SELECTED:
+      case Event.PROPOSAL_STATUS_UPDATED:
         try {
           await Promise.all(
             event.proposalidswithnextstatus.proposalIds.map(

--- a/src/events/applicationEvents.ts
+++ b/src/events/applicationEvents.ts
@@ -111,6 +111,11 @@ interface ProposalSEPSelectedEvent extends GeneralEvent {
   proposalidswithnextstatus: ProposalIdsWithNextStatus;
 }
 
+interface ProposalStatusUpdatedEvent extends GeneralEvent {
+  type: Event.PROPOSAL_STATUS_UPDATED;
+  proposalidswithnextstatus: ProposalIdsWithNextStatus;
+}
+
 interface ProposalInstrumentSubmittedEvent extends GeneralEvent {
   type: Event.PROPOSAL_INSTRUMENT_SUBMITTED;
   instrumenthasproposals: InstrumentHasProposals;
@@ -222,6 +227,7 @@ export type ApplicationEvent =
   | ProposalClonedEvent
   | ProposalManagementDecisionUpdatedEvent
   | ProposalManagementDecisionSubmittedEvent
+  | ProposalStatusUpdatedEvent
   | UserCreateEvent
   | EmailInvite
   | UserResetPasswordEmailEvent

--- a/src/events/event.enum.ts
+++ b/src/events/event.enum.ts
@@ -20,6 +20,7 @@ export enum Event {
   PROPOSAL_INSTRUMENT_SUBMITTED = 'PROPOSAL_INSTRUMENT_SUBMITTED',
   PROPOSAL_ACCEPTED = 'PROPOSAL_ACCEPTED',
   PROPOSAL_REJECTED = 'PROPOSAL_REJECTED',
+  PROPOSAL_STATUS_UPDATED = 'PROPOSAL_STATUS_UPDATED',
   CALL_ENDED = 'CALL_ENDED',
   CALL_REVIEW_ENDED = 'CALL_REVIEW_ENDED',
   CALL_SEP_REVIEW_ENDED = 'CALL_SEP_REVIEW_ENDED',
@@ -109,6 +110,10 @@ export const EventLabel = new Map<Event, string>([
     'Event occurs when proposal management decision is submitted',
   ],
   [Event.PROPOSAL_REJECTED, 'Event occurs when proposal gets rejected'],
+  [
+    Event.PROPOSAL_STATUS_UPDATED,
+    'Event occurs when proposal status gets updated manually',
+  ],
   [
     Event.CALL_ENDED,
     'Event occurs on a specific call end date set on the call',

--- a/src/mutations/ProposalMutations.ts
+++ b/src/mutations/ProposalMutations.ts
@@ -15,11 +15,12 @@ import { ProposalDataSource } from '../datasources/ProposalDataSource';
 import { QuestionaryDataSource } from '../datasources/QuestionaryDataSource';
 import { Authorized, EventBus, ValidateArgs } from '../decorators';
 import { Event } from '../events/event.enum';
-import { Proposal } from '../models/Proposal';
+import { Proposal, ProposalIdsWithNextStatus } from '../models/Proposal';
 import { Roles } from '../models/Role';
 import { UserWithRole } from '../models/User';
 import { rejection, Rejection } from '../rejection';
 import { AdministrationProposalArgs } from '../resolvers/mutations/AdministrationProposal';
+import { ChangeProposalsStatusInput } from '../resolvers/mutations/ChangeProposalsStatusMutation';
 import { CloneProposalInput } from '../resolvers/mutations/CloneProposalMutation';
 import { UpdateProposalArgs } from '../resolvers/mutations/UpdateProposalMutation';
 import { UserAuthorization } from '../utils/UserAuthorization';
@@ -323,6 +324,23 @@ export default class ProposalMutations {
     }
 
     const result = await this.proposalDataSource.update(proposal);
+
+    return result || rejection('INTERNAL_ERROR');
+  }
+
+  // @EventBus(Event.PROPOSAL_STATUS_UPDATED)
+  @ValidateArgs(administrationProposalValidationSchema)
+  @Authorized([Roles.USER_OFFICER])
+  async changeProposalsStatus(
+    agent: UserWithRole | null,
+    args: ChangeProposalsStatusInput
+  ): Promise<ProposalIdsWithNextStatus | Rejection> {
+    const { statusId, proposalIds } = args;
+
+    const result = await this.proposalDataSource.changeProposalsStatus(
+      statusId,
+      proposalIds
+    );
 
     return result || rejection('INTERNAL_ERROR');
   }

--- a/src/mutations/ProposalMutations.ts
+++ b/src/mutations/ProposalMutations.ts
@@ -347,13 +347,15 @@ export default class ProposalMutations {
     );
 
     if (result.proposalIds.length === proposals.length) {
-      proposals.forEach(async (proposal) => {
-        await this.proposalDataSource.resetProposalEvents(
-          proposal.id,
-          proposal.callId,
-          statusId
-        );
-      });
+      await Promise.all(
+        proposals.map((proposal) => {
+          return this.proposalDataSource.resetProposalEvents(
+            proposal.id,
+            proposal.callId,
+            statusId
+          );
+        })
+      );
     }
 
     return result || rejection('INTERNAL_ERROR');

--- a/src/resolvers/mutations/AssignProposalsToInstrumentMutation.ts
+++ b/src/resolvers/mutations/AssignProposalsToInstrumentMutation.ts
@@ -6,27 +6,18 @@ import {
   Mutation,
   Resolver,
   Int,
-  InputType,
 } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
 import { isRejection } from '../../rejection';
 import { SuccessResponseWrap } from '../types/CommonWrappers';
 import { wrapResponse } from '../wrapResponse';
-
-@InputType()
-export class ProposalsToInstrumentArgs {
-  @Field(() => Int)
-  public id: number;
-
-  @Field(() => Int)
-  public callId: number;
-}
+import { ProposalIdWithCallId } from './ChangeProposalsStatusMutation';
 
 @ArgsType()
 export class AssignProposalsToInstrumentArgs {
-  @Field(() => [ProposalsToInstrumentArgs])
-  public proposals: ProposalsToInstrumentArgs[];
+  @Field(() => [ProposalIdWithCallId])
+  public proposals: ProposalIdWithCallId[];
 
   @Field(() => Int)
   public instrumentId: number;

--- a/src/resolvers/mutations/ChangeProposalsStatusMutation.ts
+++ b/src/resolvers/mutations/ChangeProposalsStatusMutation.ts
@@ -1,0 +1,40 @@
+import {
+  Ctx,
+  Mutation,
+  Resolver,
+  Arg,
+  Int,
+  Field,
+  InputType,
+} from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { SuccessResponseWrap } from '../types/CommonWrappers';
+import { wrapResponse } from '../wrapResponse';
+
+@InputType()
+export class ChangeProposalsStatusInput {
+  @Field(() => Int)
+  public statusId: number;
+
+  @Field(() => [Int])
+  public proposalIds: number[];
+}
+
+@Resolver()
+export class ChangeProposalsStatusMutation {
+  @Mutation(() => SuccessResponseWrap)
+  cloneProposal(
+    @Arg('changeProposalsStatusInput')
+    changeProposalsStatusInput: ChangeProposalsStatusInput,
+    @Ctx() context: ResolverContext
+  ) {
+    return wrapResponse(
+      context.mutations.proposal.changeProposalsStatus(
+        context.user,
+        changeProposalsStatusInput
+      ),
+      SuccessResponseWrap
+    );
+  }
+}

--- a/src/resolvers/mutations/ChangeProposalsStatusMutation.ts
+++ b/src/resolvers/mutations/ChangeProposalsStatusMutation.ts
@@ -9,31 +9,43 @@ import {
 } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
+import { isRejection } from '../../rejection';
 import { SuccessResponseWrap } from '../types/CommonWrappers';
 import { wrapResponse } from '../wrapResponse';
+
+@InputType()
+export class ProposalIdWithCallId {
+  @Field(() => Int)
+  public id: number;
+
+  @Field(() => Int)
+  public callId: number;
+}
 
 @InputType()
 export class ChangeProposalsStatusInput {
   @Field(() => Int)
   public statusId: number;
 
-  @Field(() => [Int])
-  public proposalIds: number[];
+  @Field(() => [ProposalIdWithCallId])
+  public proposals: ProposalIdWithCallId[];
 }
 
 @Resolver()
 export class ChangeProposalsStatusMutation {
   @Mutation(() => SuccessResponseWrap)
-  cloneProposal(
+  async changeProposalsStatus(
     @Arg('changeProposalsStatusInput')
     changeProposalsStatusInput: ChangeProposalsStatusInput,
     @Ctx() context: ResolverContext
   ) {
+    const res = await context.mutations.proposal.changeProposalsStatus(
+      context.user,
+      changeProposalsStatusInput
+    );
+
     return wrapResponse(
-      context.mutations.proposal.changeProposalsStatus(
-        context.user,
-        changeProposalsStatusInput
-      ),
+      isRejection(res) ? Promise.resolve(res) : Promise.resolve(true),
       SuccessResponseWrap
     );
   }


### PR DESCRIPTION
## Description

Status change on multiple proposals at once

## Motivation and Context

Previously if you wanted to change proposal status you should do it manually one by one proposal.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1396


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
