### PR TITLE
SWAP-1490 The file name when downloading xls file is unknown

### DIFF
--- a/src/factory/xlsx/sep.ts
+++ b/src/factory/xlsx/sep.ts
@@ -1,7 +1,6 @@
 import baseContext from '../../buildContext';
 import { UserWithRole } from '../../models/User';
 import { average, getGrades } from '../../utils/mathFunctions';
-import { getCurrentTimestamp } from '../util';
 
 type SEPXLSXData = Array<{
   sheetName: string;
@@ -73,6 +72,12 @@ export const collectSEPlXLSXData = async (
   callId: number,
   user: UserWithRole
 ): Promise<{ data: SEPXLSXData; filename: string }> => {
+  const sep = await baseContext.queries.sep.get(user, sepId);
+  const call = await baseContext.queries.call.get(user, callId);
+
+  // TODO: decide on filename
+  const filename = `SEP-${sep?.code}-${call?.shortCode}.xlsx`;
+
   const instruments = await baseContext.queries.instrument.getInstrumentsBySepId(
     user,
     {
@@ -199,7 +204,7 @@ export const collectSEPlXLSXData = async (
         row.principalInv,
         row.instrAvailTime ?? '<missing>',
         row.techReviewTimeAllocation ?? '<missing>',
-        row.sepTimeAllocation ?? '<missing>',
+        row.sepTimeAllocation ?? row.techReviewTimeAllocation ?? '<missing>',
         row.propReviewAvgScore ?? '<missing>',
         row.propSEPRankOrder ?? '<missing>',
         row.inAvailZone ?? '<missing>',
@@ -207,10 +212,8 @@ export const collectSEPlXLSXData = async (
     });
   });
 
-  //
   return {
     data: out,
-    // TODO: decide on filename
-    filename: `SEP_${getCurrentTimestamp()}.xlsx`,
+    filename: filename.replace(/\s+/g, '_'),
   };
 };

--- a/src/middlewares/factory/xlsx.ts
+++ b/src/middlewares/factory/xlsx.ts
@@ -76,19 +76,17 @@ router.get(`/${XLSXType.SEP}/:sep_id/call/:call_id`, async (req, res, next) => {
       );
     }
 
-    const meta: XLSXMetaBase = {
-      singleFilename: '',
-      collectionFilename: '', // not used
-      columns: defaultSEPDataColumns,
-    };
-
     const { data, filename } = await collectSEPlXLSXData(
       sepId,
       callId,
       userWithRole
     );
 
-    meta.singleFilename = filename;
+    const meta: XLSXMetaBase = {
+      singleFilename: filename,
+      collectionFilename: filename,
+      columns: defaultSEPDataColumns,
+    };
 
     callFactoryService(
       DownloadType.XLSX,


### PR DESCRIPTION
## Description

This PR fixes the filename for SEP XLSX export and also changes the sep time allocation fallback to technical review's time allocation.
<!--- Describe your changes in detail -->

## Motivation and Context

Currently, if there is more than one instrument for a given SEP & call pair, the filename is not set properly.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

- [x] manual test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

https://jira.esss.lu.se/browse/SWAP-1490
<!--- Does this fix a user story, if so add a reference here -->

## Changes

- sep xlsx: fix filename for collection
- if sep time is not set fallback to technical review time
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
