### PR TITLE
SWAP-1508 #resolved

### DIFF
--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -304,7 +304,13 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     offset?: number
   ): Promise<{ totalCount: number; proposals: Proposal[] }> {
     return database
-      .select(['*', database.raw('count(*) OVER() AS full_count')])
+      .select([
+        'proposals.*',
+        'instrument_has_scientists.*',
+        'instrument_has_proposals.instrument_id',
+        'instrument_has_proposals.proposal_id',
+        database.raw('count(*) OVER() AS full_count'),
+      ])
       .from('proposals')
       .join('instrument_has_scientists', {
         'instrument_has_scientists.user_id': scientistId,


### PR DESCRIPTION
## Description

Because of the join I think there was conflict with the `submitted` fields from `proposal` table and `instrument_has_proposals` table and it was taking the one from `instrument_has_proposals`. We don't need that one in this query and I did more specific selection so this field is excluded and the one from proposals table is used.

## How Has This Been Tested

manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1508


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
