### PR TITLE
Update Windows base image names

### DIFF
--- a/Dockerfile.dev.win
+++ b/Dockerfile.dev.win
@@ -1,5 +1,5 @@
 ARG WINDOWS_VERSION
-FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT
+FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12-servercore${WINDOWS_VERSION}
 
 # The Git repo should be mounted from the host into this directory
 WORKDIR /app

--- a/Dockerfile.dev.win
+++ b/Dockerfile.dev.win
@@ -6,5 +6,4 @@ WORKDIR /app
 
 EXPOSE 4000
 
-
 CMD ["npm.cmd", "run", "dev:docker"]

--- a/Dockerfile.dev.win
+++ b/Dockerfile.dev.win
@@ -6,4 +6,5 @@ WORKDIR /app
 
 EXPOSE 4000
 
+
 CMD ["npm.cmd", "run", "dev:docker"]

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,5 +1,5 @@
 ARG WINDOWS_VERSION
-FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT AS build-stage
+FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12.19.0-servercore${WINDOWS_VERSION} AS build-stage
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ COPY . .
 RUN npm run tsc
 
 
-FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12-servercore${WINDOWS_VERSION}-1.0.0-SNAPSHOT
+FROM docker-registry.devs.facilities.rl.ac.uk/bisapps-node:12.19.0-servercore${WINDOWS_VERSION}
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
We've recently renamed our Node base image, so we just have to update the Dockerfiles to match the new name.

Note that the "prod" Dockerfile uses a specific Node version, while the dev version just pulls the lastest Node 12.x.

## Motivation and Context
We're trying to have simpler names for our base images.

Internally, this is part of isisbusapps/docker-base-images#39.

## How Has This Been Tested
The Dockerfiles were built locally.
