### PR TITLE
Disable RabbitMQ handler in STFC config

### DIFF
--- a/src/config/dependencyConfigSTFC.ts
+++ b/src/config/dependencyConfigSTFC.ts
@@ -14,7 +14,7 @@ import PostgreSystemDataSource from '../datasources/postgres/SystemDataSource';
 import PostgresTemplateDataSource from '../datasources/postgres/TemplateDataSource';
 import { StfcUserDataSource } from '../datasources/stfc/StfcUserDataSource';
 import { SMTPMailService } from '../eventHandlers/MailService/SMTPMailService';
-import { createPostToRabbitMQHandler } from '../eventHandlers/messageBroker';
+import { createSkipPostingHandler } from '../eventHandlers/messageBroker';
 import { SkipAssetRegistrar } from '../utils/EAM_service';
 import { QuestionaryAuthorization } from '../utils/QuestionaryAuthorization';
 import { SampleAuthorization } from '../utils/SampleAuthorization';
@@ -48,4 +48,4 @@ mapClass(Tokens.AssetRegistrar, SkipAssetRegistrar);
 
 mapClass(Tokens.MailService, SMTPMailService);
 
-mapValue(Tokens.PostToMessageQueue, createPostToRabbitMQHandler());
+mapValue(Tokens.PostToMessageQueue, createSkipPostingHandler());


### PR DESCRIPTION
## Description
Removes the RabbitMQ handler from the STFC dependency config, as we're not currently running RabbitMQ.

## Motivation and Context
This removes a lot of errors in the backend logs about not being able to connect to RabbitMQ.

## How Has This Been Tested
Tested locally on my PC
