### PR TITLE
Swap 1526 Clean up questionnaire data

### DIFF
--- a/db_patches/0091_CleanupQuestionaryDataAfterDelete.sql
+++ b/db_patches/0091_CleanupQuestionaryDataAfterDelete.sql
@@ -1,0 +1,51 @@
+DO
+$$
+BEGIN
+	IF register_patch('CleanupAfterProposalDelete.sql', 'jekabskarklins', 'Clean up data when deleting proposal', '2021-04-27') THEN
+
+        /* Delete proposal questionary data  */
+        CREATE OR REPLACE FUNCTION after_proposal_delete() RETURNS trigger AS $body$
+        BEGIN
+            DELETE FROM 
+                questionaries
+            WHERE
+                questionary_id = old.questionary_id;
+        RETURN old;
+        END;
+        $body$ LANGUAGE 'plpgsql';
+
+        CREATE TRIGGER proposal_delete_trigger AFTER DELETE ON "proposals"
+        FOR EACH ROW EXECUTE PROCEDURE after_proposal_delete();
+
+        /* Delete sample questionary data  */
+        CREATE OR REPLACE FUNCTION after_sample_delete() RETURNS trigger AS $body$
+        BEGIN
+            DELETE FROM 
+                questionaries
+            WHERE
+                questionary_id = old.questionary_id;
+        RETURN old;
+        END;
+        $body$ LANGUAGE 'plpgsql';
+
+        CREATE TRIGGER sample_delete_trigger AFTER DELETE ON "samples"
+        FOR EACH ROW EXECUTE PROCEDURE after_sample_delete();
+
+        /* Delete shipment questionary data  */
+        CREATE OR REPLACE FUNCTION after_shipment_delete() RETURNS trigger AS $body$
+        BEGIN
+            DELETE FROM 
+                questionaries
+            WHERE
+                questionary_id = old.questionary_id;
+        RETURN old;
+        END;
+        $body$ LANGUAGE 'plpgsql';
+
+        CREATE TRIGGER shipment_delete_trigger AFTER DELETE ON "shipments"
+        FOR EACH ROW EXECUTE PROCEDURE after_shipment_delete();
+
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/example.env
+++ b/example.env
@@ -34,4 +34,3 @@ baseURL=localhost:3000
 tokenLife=7d
 secret=qMyLZALzs229ybdQXNyzYRdju7X784TH
 SPARKPOST_TOKEN=insertokenhere
-e

--- a/src/mutations/ProposalMutations.ts
+++ b/src/mutations/ProposalMutations.ts
@@ -224,8 +224,6 @@ export default class ProposalMutations {
     try {
       const result = await this.proposalDataSource.deleteProposal(proposalId);
 
-      await this.questionaryDataSource.delete(result.questionaryId);
-
       return result;
     } catch (e) {
       if ('code' in e && e.code === '23503') {


### PR DESCRIPTION
## Description

This PR adds cleanup routines that clean up questionnaire data when proposal, sample or shipment is deleted.

## Motivation and Context

When for example proposal is deleted we also want to  make sure that all relevant data is cleaned up

## How Has This Been Tested

 - [x] Unit tests
 - [x]  Manual tests

## Fixes

SWAP-1526


## Depends on
N/A

