### PR TITLE
sanitize input html from rich text editor

### DIFF
--- a/src/decorators/ValidateArgs.ts
+++ b/src/decorators/ValidateArgs.ts
@@ -1,7 +1,9 @@
 import { ResourceId } from '@esss-swap/duo-localisation';
 import { logger } from '@esss-swap/duo-logger';
+import sanitizeHtml from 'sanitize-html';
 import * as Yup from 'yup';
 
+import { sanitizerConfig } from '../models/questionTypes/RichTextInput';
 import { UserWithRole } from '../models/User';
 import { Rejection, rejection } from '../rejection';
 
@@ -15,7 +17,7 @@ const schemaValidation = async (schema: Yup.ObjectSchema, inputArgs: any) => {
   return null;
 };
 
-const ValidateArgs = (schema: Yup.ObjectSchema) => {
+const ValidateArgs = (schema: Yup.ObjectSchema, sanitizeInput?: string[]) => {
   return (
     target: any,
     name: string,
@@ -30,6 +32,16 @@ const ValidateArgs = (schema: Yup.ObjectSchema) => {
 
     descriptor.value = async function (...args) {
       const [, inputArgs] = args;
+
+      // NOTE: Sanitize dangerous html inputs if needed.
+      if (sanitizeInput && sanitizeInput.length > 0) {
+        sanitizeInput.forEach((inputArg) => {
+          inputArgs[inputArg] = sanitizeHtml(
+            inputArgs[inputArg],
+            sanitizerConfig
+          );
+        });
+      }
 
       const errors = await schemaValidation(schema, inputArgs);
 

--- a/src/models/questionTypes/RichTextInput.ts
+++ b/src/models/questionTypes/RichTextInput.ts
@@ -8,7 +8,7 @@ import { DataType, QuestionTemplateRelation } from '../Template';
 import { Question } from './QuestionRegistry';
 
 // explicitly limit the accepted elements, attributes, styles
-const sanitizerConfig: IOptions = {
+export const sanitizerConfig: IOptions = {
   allowedTags: [
     'p',
     'span',

--- a/src/mutations/AdminMutations.ts
+++ b/src/mutations/AdminMutations.ts
@@ -52,7 +52,7 @@ export default class AdminMutations {
     return this.dataSource.applyPatches();
   }
 
-  @ValidateArgs(setPageTextValidationSchema)
+  @ValidateArgs(setPageTextValidationSchema, ['text'])
   @Authorized([Roles.USER_OFFICER])
   async setPageText(
     agent: UserWithRole | null,

--- a/src/mutations/ProposalMutations.ts
+++ b/src/mutations/ProposalMutations.ts
@@ -262,8 +262,10 @@ export default class ProposalMutations {
   }
 
   @EventBus(Event.PROPOSAL_MANAGEMENT_DECISION_UPDATED)
-  @EventBus(Event.PROPOSAL_STATUS_CHANGED_BY_USER)
-  @ValidateArgs(administrationProposalValidationSchema)
+  @ValidateArgs(administrationProposalValidationSchema, [
+    'commentForUser',
+    'commentForManagement',
+  ])
   @Authorized([Roles.USER_OFFICER, Roles.SEP_CHAIR, Roles.SEP_SECRETARY])
   async admin(
     agent: UserWithRole | null,

--- a/src/mutations/ReviewMutations.ts
+++ b/src/mutations/ReviewMutations.ts
@@ -37,7 +37,7 @@ export default class ReviewMutations {
   ) {}
 
   @EventBus(Event.PROPOSAL_SEP_REVIEW_UPDATED)
-  @ValidateArgs(proposalGradeValidationSchema)
+  @ValidateArgs(proposalGradeValidationSchema, ['comment'])
   @Authorized()
   async updateReview(
     agent: UserWithRole | null,
@@ -125,7 +125,10 @@ export default class ReviewMutations {
   }
 
   @EventBus(Event.PROPOSAL_FEASIBILITY_REVIEW_UPDATED)
-  @ValidateArgs(proposalTechnicalReviewValidationSchema)
+  @ValidateArgs(proposalTechnicalReviewValidationSchema, [
+    'comment',
+    'publicComment',
+  ])
   @Authorized([Roles.USER_OFFICER, Roles.INSTRUMENT_SCIENTIST])
   async setTechnicalReview(
     agent: UserWithRole | null,

--- a/src/mutations/SEPMutations.ts
+++ b/src/mutations/SEPMutations.ts
@@ -401,7 +401,10 @@ export default class SEPMutations {
       });
   }
 
-  @ValidateArgs(saveSepMeetingDecisionValidationSchema)
+  @ValidateArgs(saveSepMeetingDecisionValidationSchema, [
+    'commentForUser',
+    'commentForManagement',
+  ])
   @Authorized([Roles.USER_OFFICER, Roles.SEP_CHAIR, Roles.SEP_SECRETARY])
   @EventBus(Event.PROPOSAL_SEP_MEETING_SAVED)
   async saveSepMeetingDecision(


### PR DESCRIPTION
## Description

Because of the change in the frontend from normal textarea to richtext input we need to sanitize the html string on every input where it is needed. The check is added inside `ValidateArgs` decorator and it sanitizes the input args passed as second parameter on the decorator.

## How Has This Been Tested

e2e tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1523


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
