### PR TITLE
try new tag and release action

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Extracted branch
         run: echo "Extracted branch ${{ steps.extract_branch.outputs.branch }}"
 
+      # Build and push only for 'develop' branch because for 'master' we have another action that builds release image
       - name: Build and push
+        if: steps.extract_branch.outputs.branch == 'develop'
         id: docker_build
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -21,3 +21,21 @@ jobs:
           tag_name: ${{ steps.tag_version.outputs.new_tag }}
           release_name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+        # Build and push release image tagged with the same tag as github release
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          build-args: BUILD_VERSION=${{ github.sha }}
+          push: true
+          tags: dmsc/duo-backend:${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -1,0 +1,23 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v5.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create a GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
## Description

A GitHub Action to automatically bump and tag master, on merge of a pull request.

## Motivation and Context

Previously this was done manually to tag and create a release.

## How Has This Been Tested

Manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-1474

## Changes

Added new github action called `github-tag-and-release`


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
