### PR TITLE
patch: Remove unnecessary awaits for isUserOfficer

### DIFF
--- a/src/mutations/SampleMutations.ts
+++ b/src/mutations/SampleMutations.ts
@@ -102,7 +102,7 @@ export default class SampleMutations {
     // Thi makes sure administrative fields can be only updated by user with the right role
     if (args.safetyComment || args.safetyStatus) {
       const canAdministrerSample =
-        (await this.userAuthorization.isUserOfficer(agent)) ||
+        this.userAuthorization.isUserOfficer(agent) ||
         (await this.userAuthorization.isSampleSafetyReviewer(agent));
       if (canAdministrerSample === false) {
         delete args.safetyComment;

--- a/src/mutations/UserMutations.ts
+++ b/src/mutations/UserMutations.ts
@@ -106,7 +106,7 @@ export default class UserMutations {
 
     if (
       args.userRole === UserRole.SEP_REVIEWER &&
-      (await this.userAuth.isUserOfficer(agent))
+      this.userAuth.isUserOfficer(agent)
     ) {
       userId = await this.dataSource.createInviteUser(args);
       await this.dataSource.setUserRoles(userId, [UserRole.SEP_REVIEWER]);
@@ -117,20 +117,20 @@ export default class UserMutations {
       role = UserRole.USER;
     } else if (
       args.userRole === UserRole.SEP_CHAIR &&
-      (await this.userAuth.isUserOfficer(agent))
+      this.userAuth.isUserOfficer(agent)
     ) {
       // NOTE: For inviting SEP_CHAIR and SEP_SECRETARY we do not setUserRoles because they are set right after in separate call.
       userId = await this.dataSource.createInviteUser(args);
       role = UserRole.SEP_CHAIR;
     } else if (
       args.userRole === UserRole.SEP_SECRETARY &&
-      (await this.userAuth.isUserOfficer(agent))
+      this.userAuth.isUserOfficer(agent)
     ) {
       userId = await this.dataSource.createInviteUser(args);
       role = UserRole.SEP_SECRETARY;
     } else if (
       args.userRole === UserRole.INSTRUMENT_SCIENTIST &&
-      (await this.userAuth.isUserOfficer(agent))
+      this.userAuth.isUserOfficer(agent)
     ) {
       userId = await this.dataSource.createInviteUser(args);
       role = UserRole.INSTRUMENT_SCIENTIST;
@@ -265,8 +265,8 @@ export default class UserMutations {
     args: UpdateUserArgs
   ): Promise<User | Rejection> {
     if (
-      !(await this.userAuth.isUserOfficer(agent)) &&
-      !(await this.userAuth.isUser(agent, args.id))
+      !this.userAuth.isUserOfficer(agent) &&
+      !this.userAuth.isUser(agent, args.id)
     ) {
       return rejection(
         'Can not update user because of insufficient permissions',
@@ -532,8 +532,8 @@ export default class UserMutations {
     { id, password }: { id: number; password: string }
   ): Promise<BasicUserDetails | Rejection> {
     if (
-      !(await this.userAuth.isUserOfficer(agent)) &&
-      !(await this.userAuth.isUser(agent, id))
+      !this.userAuth.isUserOfficer(agent) &&
+      !this.userAuth.isUser(agent, id)
     ) {
       return rejection(
         'Can not update password because of insufficient permissions',

--- a/src/queries/CallQueries.ts
+++ b/src/queries/CallQueries.ts
@@ -41,10 +41,7 @@ export default class CallQueries {
     agent: UserWithRole | null,
     scientistId: number
   ) {
-    if (
-      !(await this.userAuth.isUserOfficer(agent)) &&
-      agent?.id !== scientistId
-    ) {
+    if (!this.userAuth.isUserOfficer(agent) && agent?.id !== scientistId) {
       return null;
     }
 

--- a/src/utils/QuestionaryAuthorization.ts
+++ b/src/utils/QuestionaryAuthorization.ts
@@ -90,7 +90,7 @@ class SampleDeclarationQuestionaryAuthorizer implements QuestionaryAuthorizer {
       return false;
     }
 
-    if (await this.userAuthorization.isUserOfficer(agent)) {
+    if (this.userAuthorization.isUserOfficer(agent)) {
       return true;
     }
 
@@ -146,7 +146,7 @@ class ShipmentDeclarationQuestionaryAuthorizer
       return false;
     }
 
-    if (await this.userAuthorization.isUserOfficer(agent)) {
+    if (this.userAuthorization.isUserOfficer(agent)) {
       return true;
     }
 

--- a/src/utils/SampleAuthorization.ts
+++ b/src/utils/SampleAuthorization.ts
@@ -26,7 +26,7 @@ export class SampleAuthorization {
   }
 
   private async hasAccessRights(agent: UserWithRole | null, sampleId: number) {
-    if (await this.userAuthorization.isUserOfficer(agent)) {
+    if (this.userAuthorization.isUserOfficer(agent)) {
       return true;
     }
 

--- a/src/utils/ShipmentAuthorization.ts
+++ b/src/utils/ShipmentAuthorization.ts
@@ -36,7 +36,7 @@ export class ShipmentAuthorization {
     agent: UserWithRole | null,
     shipmentId: number | number[]
   ) {
-    if (await this.userAuthorization.isUserOfficer(agent)) {
+    if (this.userAuthorization.isUserOfficer(agent)) {
       return true;
     }
 


### PR DESCRIPTION
## Description

isUserOfficer is a synchronous method, but many places in the code it was used as async.

## Motivation and Context

Cleaning up and improving readibility

## Depends on

N/A

