### PR TITLE
feat(shipments): Adding MyShipments endpoint

### DIFF
--- a/src/queries/ShipmentQueries.ts
+++ b/src/queries/ShipmentQueries.ts
@@ -30,6 +30,7 @@ export default class ShipmentQueries {
     return this.dataSource.get(shipmentId);
   }
 
+  @Authorized([Roles.USER_OFFICER])
   async getShipments(agent: UserWithRole | null, args: ShipmentsArgs) {
     let shipments = await this.dataSource.getAll(args);
 
@@ -45,5 +46,20 @@ export default class ShipmentQueries {
   @Authorized([Roles.USER_OFFICER, Roles.SAMPLE_SAFETY_REVIEWER])
   async getShipmentsByCallId(user: UserWithRole | null, callId: number) {
     return await this.dataSource.getShipmentsByCallId(callId);
+  }
+
+  @Authorized([Roles.USER])
+  async getMyShipments(agent: UserWithRole | null) {
+    let shipments = await this.dataSource.getAll({
+      filter: { creatorId: agent!.id },
+    });
+
+    shipments = await Promise.all(
+      shipments.map((shipment) =>
+        this.shipmentAuthorization.hasReadRights(agent, shipment.id)
+      )
+    ).then((results) => shipments.filter((_v, index) => results[index]));
+
+    return shipments;
   }
 }

--- a/src/resolvers/queries/MyShipmentsQuery.ts
+++ b/src/resolvers/queries/MyShipmentsQuery.ts
@@ -1,0 +1,16 @@
+import { Ctx, Query, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { Shipment } from '../types/Shipment';
+
+@Resolver()
+export class MyShipmentsQuery {
+  @Query(() => [Shipment], { nullable: true })
+  async myShipments(@Ctx() context: ResolverContext) {
+    const response = await context.queries.shipment.getMyShipments(
+      context.user
+    );
+
+    return response;
+  }
+}


### PR DESCRIPTION
## Description

Previously user called `getShipments` without any parameters. That obtained all shipments, and then authorizer filtered out the ones not belonging to you. This did work, however was very slow. 

Now there is a new dedicated endpoint `myShipments`, which returns shipments filtering out by creatorId which is obtained from the authentication session.

## Fixes

SWAP-1596

## Changes

shipments

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


