### PR TITLE
feat: Adding time to DateComponent

### DIFF
--- a/src/models/questionTypes/Date.ts
+++ b/src/models/questionTypes/Date.ts
@@ -58,6 +58,7 @@ export const dateDefinition: Question = {
     config.small_label = '';
     config.required = false;
     config.tooltip = '';
+    config.includeTime = false;
 
     return config;
   },

--- a/src/resolvers/types/FieldConfig.ts
+++ b/src/resolvers/types/FieldConfig.ts
@@ -31,6 +31,9 @@ export class DateConfig extends ConfigBase {
 
   @Field(() => String, { nullable: true })
   defaultDate: string | null;
+
+  @Field(() => Boolean)
+  includeTime: boolean;
 }
 
 @ObjectType()


### PR DESCRIPTION
## Description

This PR aims to add functionality so that user can add time when specifying date. The time is optional and can be configured per question basis.

## Motivation and Context

The datetime is stored in the database in ISO datetime format, without timezone. ISO specification therefore says that without timezone formatted time means that time is in local timezone. We are omitting the timezone due to lack of good support for that in JS date object and datetime pickers. 



## Fixes
SWAP-1601



## Depends on
https://github.com/UserOfficeProject/user-office-frontend/pull/392


## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.

