### PR TITLE
Disable external auth feature flag

### DIFF
--- a/db_patches/0095_SetAuthFeatureFalse.sql
+++ b/db_patches/0095_SetAuthFeatureFalse.sql
@@ -1,0 +1,16 @@
+DO
+$$
+BEGIN
+	IF register_patch('SetAuthFeatureFalse.sql', 'jekabskarklins', 'Set STFC auth to disabled', '2021-06-03') THEN
+	BEGIN
+      UPDATE 
+        features
+      SET 
+        is_enabled = false
+      WHERE
+        feature_id = 'EXTERNAL_AUTH';
+    END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

Disable external auth feature flag, for now until we can separate db_patches so that the flag do not interfere with e2e tests

## Fixes

SWAP-1643

## Changes

db patches
