### PR TITLE
Allow for customisable footer content

### DIFF
--- a/db_patches/0097_AddFooterPageContent.sql
+++ b/db_patches/0097_AddFooterPageContent.sql
@@ -1,0 +1,16 @@
+DO
+$$
+BEGIN
+	IF register_patch('AddFooterPageContent.sql', 'Simon Fernandes', 'Add footer content to pagetext table', '2021-06-09') THEN
+	
+		BEGIN
+		  INSERT INTO 
+			pagetext(pagetext_id, content)
+		  VALUES
+			('6', '');
+		END;
+		
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -4,4 +4,5 @@ export enum PageName {
   PRIVACYPAGE = 3,
   COOKIEPAGE = 4,
   REVIEWPAGE = 5,
+  FOOTERCONTENT = 6,
 }

--- a/src/models/questionTypes/RichTextInput.ts
+++ b/src/models/questionTypes/RichTextInput.ts
@@ -10,6 +10,7 @@ import { Question } from './QuestionRegistry';
 // explicitly limit the accepted elements, attributes, styles
 export const sanitizerConfig: IOptions = {
   allowedTags: [
+    'a',
     'p',
     'span',
     'strong',
@@ -29,6 +30,7 @@ export const sanitizerConfig: IOptions = {
   ],
   disallowedTagsMode: 'discard',
   allowedAttributes: {
+    a: ['href', 'title'],
     span: ['style'],
     p: ['style'],
   },


### PR DESCRIPTION
## Description

This adds another page for footer content that accepts user input. It displays at the bottom of the page above the existing privacy and faq links.

As with the privacy and faq links, if there is no content defined, it won't be shown. So one or the other can be shown.

## Motivation and Context

STFC needs a way of being able to show custom content in the footer that may be subject to change over time.

## How Has This Been Tested

Just tested locally by having a play with adding/removing content.

## Fixes

Part of UserOfficeProject/stfc-user-office-project#141

Doesn't close the issue because we'll eventually need a STFC-specific patch to add the actual content.

## Depends on

Frontend changes - https://github.com/UserOfficeProject/user-office-frontend/pull/414

## Changes

Please take notice of commit af53674 - this allows links when sanitising the HTML input. Links wouldn't work without this. I think this will be okay since it's only user officers who can write this HTML, but I'm not sure on the reasons for excluding it originally.

If this is a problem, I think we might be able to restrict links to protocols (e.g. HTTP, HTTPS) and maybe there's a way to only allow links to particular domains.

## Screenshot

![image](https://user-images.githubusercontent.com/14293717/121524454-3f390400-c9ef-11eb-83e0-5c8a38883076.png)

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
