### PR TITLE
feat: Visitations can be only about accepted proposal BREAKING CHANGE

### DIFF
--- a/src/datasources/ProposalDataSource.ts
+++ b/src/datasources/ProposalDataSource.ts
@@ -3,6 +3,7 @@ import { Call } from '../models/Call';
 import { Proposal, ProposalIdsWithNextStatus } from '../models/Proposal';
 import { ProposalView } from '../models/ProposalView';
 import { UpdateTechnicalReviewAssigneeInput } from '../resolvers/mutations/UpdateTechnicalReviewAssignee';
+import { UserProposalsFilter } from '../resolvers/types/User';
 import { ProposalsFilter } from './../resolvers/queries/ProposalsQuery';
 import { ProposalEventsRecord } from './postgres/records';
 
@@ -24,7 +25,7 @@ export interface ProposalDataSource {
   ): Promise<{ totalCount: number; proposals: Proposal[] }>;
   getUserProposals(
     id: number,
-    filter?: { instrumentId?: number | null }
+    filter?: UserProposalsFilter
   ): Promise<Proposal[]>;
 
   // Write

--- a/src/datasources/mockups/ProposalDataSource.ts
+++ b/src/datasources/mockups/ProposalDataSource.ts
@@ -85,6 +85,7 @@ export class ProposalDataSourceMock implements ProposalDataSource {
       submitted: true,
       finalStatus: ProposalEndStatus.ACCEPTED,
       notified: true,
+      managementDecisionSubmitted: true,
     });
 
     dummyProposalWithNotActiveCall = dummyProposalFactory({
@@ -183,7 +184,7 @@ export class ProposalDataSourceMock implements ProposalDataSource {
   }
 
   async getInstrumentScientistProposals(
-    scientsitId: number,
+    scientistId: number,
     filter?: ProposalsFilter,
     first?: number,
     offset?: number

--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -8,6 +8,7 @@ import { Proposal, ProposalIdsWithNextStatus } from '../../models/Proposal';
 import { ProposalView } from '../../models/ProposalView';
 import { getQuestionDefinition } from '../../models/questionTypes/QuestionRegistry';
 import { UpdateTechnicalReviewAssigneeInput } from '../../resolvers/mutations/UpdateTechnicalReviewAssignee';
+import { UserProposalsFilter } from '../../resolvers/types/User';
 import { ProposalDataSource } from '../ProposalDataSource';
 import { ProposalsFilter } from './../../resolvers/queries/ProposalsQuery';
 import database from './database';
@@ -490,7 +491,7 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
 
   async getUserProposals(
     id: number,
-    filter?: { instrumentId?: number | null }
+    filter?: UserProposalsFilter
   ): Promise<Proposal[]> {
     return database
       .select('p.*')
@@ -506,6 +507,17 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
             'p.proposal_id': 'ihp.proposal_id',
           });
           qb.where('ihp.instrument_id', filter.instrumentId);
+        }
+
+        if (filter?.managementDecisionSubmitted) {
+          qb.where(
+            'p.management_decision_submitted',
+            filter.managementDecisionSubmitted
+          );
+        }
+
+        if (filter?.finalStatus) {
+          qb.where('p.final_status', filter.finalStatus);
         }
       })
       .groupBy('p.proposal_id')

--- a/src/mutations/AdminMutations.ts
+++ b/src/mutations/AdminMutations.ts
@@ -75,7 +75,7 @@ export default class AdminMutations {
   ) {
     const institution = await this.dataSource.getInstitution(args.id);
     if (!institution) {
-      return rejection('Could not retrieve insititutions');
+      return rejection('Could not retrieve institutions');
     }
 
     institution.name = args.name ?? institution.name;

--- a/src/mutations/VisitMutations.spec.ts
+++ b/src/mutations/VisitMutations.spec.ts
@@ -19,11 +19,17 @@ beforeEach(() => {
 
 test('User can create visit for his proposal', async () => {
   await expect(
-    mutations.createVisit(dummyUserWithRole, { proposalId: 1 })
+    mutations.createVisit(dummyUserWithRole, { proposalId: 2 })
   ).resolves.toBeInstanceOf(Visit);
 });
 
-test('User cannot create visit for someone elses proposal', async () => {
+test('User can not create visit for proposal that is not accepted', async () => {
+  await expect(
+    mutations.createVisit(dummyUserWithRole, { proposalId: 1 })
+  ).resolves.toBeInstanceOf(Rejection);
+});
+
+test('User can not create visit for someone elses proposal', async () => {
   await expect(
     mutations.createVisit(dummyUserWithRole, { proposalId: 99 })
   ).resolves.toBeInstanceOf(Rejection);
@@ -31,7 +37,7 @@ test('User cannot create visit for someone elses proposal', async () => {
 
 test('User can update visit', async () => {
   const visit = (await mutations.createVisit(dummyUserWithRole, {
-    proposalId: 1,
+    proposalId: 2,
   })) as Visit;
 
   expect(visit.status).toEqual(VisitStatus.DRAFT);
@@ -68,7 +74,7 @@ test('User can not delete visit that is already accepted', async () => {
   ).resolves.not.toBeInstanceOf(Rejection);
 });
 
-test('User cannot set the state to ACCEPTED', async () => {
+test('User can not set the state to ACCEPTED', async () => {
   await expect(
     mutations.updateVisit(dummyUserWithRole, {
       visitId: 1,
@@ -86,7 +92,7 @@ test('User officer can set the state to ACCEPTED', async () => {
   ).resolves.not.toBeInstanceOf(Rejection);
 });
 
-test('User cannot delete accepted visit', async () => {
+test('User can not delete accepted visit', async () => {
   await mutations.updateVisit(dummyUserOfficerWithRole, {
     visitId: 1,
     status: VisitStatus.ACCEPTED,

--- a/src/mutations/VisitMutations.ts
+++ b/src/mutations/VisitMutations.ts
@@ -5,6 +5,7 @@ import { ProposalDataSource } from '../datasources/ProposalDataSource';
 import { QuestionaryDataSource } from '../datasources/QuestionaryDataSource';
 import { TemplateDataSource } from '../datasources/TemplateDataSource';
 import { VisitDataSource } from '../datasources/VisitDataSource';
+import { ProposalEndStatus } from '../models/Proposal';
 import { rejection } from '../models/Rejection';
 import { Rejection } from '../models/Rejection';
 import { TemplateCategoryId } from '../models/Template';
@@ -42,6 +43,19 @@ export default class VisitMutations {
         args,
         agent: user,
       });
+    }
+
+    if (
+      proposal.finalStatus !== ProposalEndStatus.ACCEPTED ||
+      proposal.managementDecisionSubmitted === false
+    ) {
+      return rejection(
+        'Can not create visit, the proposal is not yet accepted',
+        {
+          args,
+          agent: user,
+        }
+      );
     }
 
     const isProposalOwner = await this.userAuthorization.hasAccessRights(

--- a/src/resolvers/types/User.ts
+++ b/src/resolvers/types/User.ts
@@ -8,9 +8,12 @@ import {
   Resolver,
   Root,
   Arg,
+  ArgsType,
+  InputType,
 } from 'type-graphql';
 
 import { ResolverContext } from '../../context';
+import { ProposalEndStatus } from '../../models/Proposal';
 import { ReviewerFilter, ReviewStatus } from '../../models/Review';
 import { User as UserOrigin } from '../../models/User';
 import { Instrument } from './Instrument';
@@ -18,6 +21,24 @@ import { Proposal } from './Proposal';
 import { Review } from './Review';
 import { Role } from './Role';
 import { SEP } from './SEP';
+
+@InputType()
+export class UserProposalsFilter {
+  @Field(() => Int, { nullable: true })
+  public instrumentId?: number;
+
+  @Field(() => Boolean, { nullable: true })
+  public managementDecisionSubmitted?: boolean;
+
+  @Field(() => ProposalEndStatus, { nullable: true })
+  public finalStatus?: ProposalEndStatus;
+}
+
+@ArgsType()
+export class UserProposalsArgs {
+  @Field(() => UserProposalsFilter, { nullable: true })
+  filter?: UserProposalsFilter;
+}
 
 @ObjectType()
 @Directive('@key(fields: "id")')
@@ -130,12 +151,13 @@ export class UserResolver {
   async proposals(
     @Root() user: User,
     @Ctx() context: ResolverContext,
-    @Arg('instrumentId', () => Int, { nullable: true })
-    instrumentId?: number | null
+    @Arg('filter', () => UserProposalsFilter, { nullable: true })
+    filter: UserProposalsFilter
   ) {
-    return context.queries.proposal.dataSource.getUserProposals(user.id, {
-      instrumentId,
-    });
+    return context.queries.proposal.dataSource.getUserProposals(
+      user.id,
+      filter
+    );
   }
 
   @FieldResolver(() => [SEP])


### PR DESCRIPTION
## Description

This PR aims to fix user story "As a user I want to see only accepted proposals when signing up for a visitation, so that I do not make any unnecessary mistakes"



## How Has This Been Tested

- [x] Added E2E tests

## Fixes

SWAP-1630


## Depends on
https://github.com/UserOfficeProject/user-office-frontend/pull/417


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.

