### PR TITLE
feat: Visitor should see the proposals he is supposed to visit

### DIFF
--- a/src/datasources/VisitDataSource.ts
+++ b/src/datasources/VisitDataSource.ts
@@ -16,4 +16,5 @@ export interface VisitDataSource {
   ): Promise<Visit>;
   updateVisit(args: UpdateVisitArgs): Promise<Visit>;
   deleteVisit(visitId: number): Promise<Visit>;
+  isVisitorOfProposal(visitorId: number, proposalPk: number): Promise<boolean>;
 }

--- a/src/datasources/mockups/VisitDataSource.ts
+++ b/src/datasources/mockups/VisitDataSource.ts
@@ -57,4 +57,11 @@ export class VisitDataSourceMock implements VisitDataSource {
       1
     )[0];
   }
+
+  async isVisitorOfProposal(
+    visitorId: number,
+    proposalPk: number
+  ): Promise<boolean> {
+    return true;
+  }
 }

--- a/src/datasources/mockups/VisitDataSource.ts
+++ b/src/datasources/mockups/VisitDataSource.ts
@@ -62,6 +62,6 @@ export class VisitDataSourceMock implements VisitDataSource {
     visitorId: number,
     proposalPk: number
   ): Promise<boolean> {
-    return true;
+    return false;
   }
 }

--- a/src/datasources/postgres/VisitDataSource.ts
+++ b/src/datasources/postgres/VisitDataSource.ts
@@ -107,6 +107,17 @@ class PostgresVisitDataSource implements VisitDataSource {
         return createVisitObject(result[0]);
       });
   }
+
+  isVisitorOfProposal(visitorId: number, proposalPk: number): Promise<boolean> {
+    return database
+      .select('*')
+      .from('visits_has_users')
+      .whereIn('visit_id', function () {
+        this.select('visit_id').from('visits').where('proposal_pk', proposalPk);
+      })
+      .andWhere('visits_has_users.user_id', visitorId)
+      .then((results) => results.length > 0);
+  }
 }
 
 export default PostgresVisitDataSource;

--- a/src/utils/UserAuthorization.ts
+++ b/src/utils/UserAuthorization.ts
@@ -7,13 +7,15 @@ import { UserDataSource } from '../datasources/UserDataSource';
 import { Proposal } from '../models/Proposal';
 import { Roles } from '../models/Role';
 import { User, UserWithRole } from '../models/User';
+import { VisitDataSource } from './../datasources/VisitDataSource';
 
 @injectable()
 export class UserAuthorization {
   constructor(
     @inject(Tokens.UserDataSource) private userDataSource: UserDataSource,
     @inject(Tokens.ReviewDataSource) private reviewDataSource: ReviewDataSource,
-    @inject(Tokens.SEPDataSource) private sepDataSource: SEPDataSource
+    @inject(Tokens.SEPDataSource) private sepDataSource: SEPDataSource,
+    @inject(Tokens.VisitDataSource) private visitDataSource: VisitDataSource
   ) {}
 
   isUserOfficer(agent: UserWithRole | null) {
@@ -127,8 +129,15 @@ export class UserAuthorization {
       (await this.isReviewerOfProposal(agent, proposal.primaryKey)) ||
       (await this.isScientistToProposal(agent, proposal.primaryKey)) ||
       (await this.isChairOrSecretaryOfProposal(agent, proposal.primaryKey)) ||
+      (await this.isVisitorOfProposal(agent, proposal.primaryKey)) ||
       this.hasGetAccessByToken(agent)
     );
+  }
+  isVisitorOfProposal(
+    agent: UserWithRole,
+    proposalPk: number
+  ): boolean | PromiseLike<boolean> {
+    return this.visitDataSource.isVisitorOfProposal(agent.id, proposalPk);
   }
 
   async isChairOrSecretaryOfSEP(


### PR DESCRIPTION
## Description

Up until now the proposal was visible only by the PI and CO-proposers. However, it is likely that visitors visiting the facility and running the experiment is neither PI nor co-proposal. Also visitors need to see the information about the proposal.

This PR enables visitors to see the proposal,

Additionally it improves database performance when proposals are selected, by having lighter query.


## Fixes

SWAP-1660

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/434

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
