### PR TITLE
feat: Attach risk assessment to the experiment time [Swap-1731]

### DIFF
--- a/db_patches/0104_AddScheduledEventIdToRiskAssessments.sql
+++ b/db_patches/0104_AddScheduledEventIdToRiskAssessments.sql
@@ -1,0 +1,22 @@
+DO
+$$
+BEGIN
+	IF register_patch('AddScheduledEventIdToRiskAssessments.sql', 'Jekabs Karklins', 'Risk assessmenet should be attached to the experiment time', '2021-08-11') THEN
+		BEGIN
+			DELETE FROM risk_assessments; -- clean up table because of new constraints
+
+			ALTER TABLE risk_assessments ADD COLUMN scheduled_event_id INTEGER NOT NULL;
+
+			ALTER TABLE risk_assessments DROP CONSTRAINT risk_assessments_proposal_pk_key;
+			ALTER TABLE risk_assessments ADD CONSTRAINT risk_assessments_proposal_pk_scheduled_event_id_key UNIQUE (proposal_pk, scheduled_event_id);
+		
+			CREATE TABLE risk_assessments_has_samples (
+				risk_assessment_id int REFERENCES risk_assessments(risk_assessment_id) ON DELETE CASCADE
+				, sample_id int REFERENCES samples(sample_id) ON DELETE CASCADE
+			); 
+
+		END;
+	END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/datasources/RiskAssessmentDataSource.ts
+++ b/src/datasources/RiskAssessmentDataSource.ts
@@ -1,5 +1,6 @@
 import { Rejection } from '../models/Rejection';
 import { RiskAssessment } from '../models/RiskAssessment';
+import { Sample } from '../models/Sample';
 import { RiskAssessmentsFilter } from '../queries/RiskAssessmentQueries';
 import { CreateRiskAssessmentArgs } from '../resolvers/mutations/CreateRiskAssesssment';
 import { UpdateRiskAssessmentArgs } from '../resolvers/mutations/UpdateRiskAssessmentMutation';
@@ -14,6 +15,7 @@ export interface RiskAssessmentDataSource {
   // Read
   getRiskAssessment(riskAssessmentId: number): Promise<RiskAssessment | null>;
   getRiskAssessments(filter: RiskAssessmentsFilter): Promise<RiskAssessment[]>;
+  getRiskAssessmentSamples(riskAssessmentId: number): Promise<Sample[]>;
 
   // Update
   updateRiskAssessment(

--- a/src/datasources/mockups/RiskAssessmentDataSource.ts
+++ b/src/datasources/mockups/RiskAssessmentDataSource.ts
@@ -3,6 +3,7 @@ import {
   RiskAssessment,
   RiskAssessmentStatus,
 } from '../../models/RiskAssessment';
+import { Sample } from '../../models/Sample';
 import { RiskAssessmentsFilter } from '../../queries/RiskAssessmentQueries';
 import { CreateRiskAssessmentArgs } from '../../resolvers/mutations/CreateRiskAssesssment';
 import { UpdateRiskAssessmentArgs } from '../../resolvers/mutations/UpdateRiskAssessmentMutation';
@@ -23,11 +24,13 @@ export class RiskAssessmentDataSourceMock implements RiskAssessmentDataSource {
         1,
         1,
         1,
+        1,
         RiskAssessmentStatus.DRAFT,
         new Date()
       ),
       new RiskAssessment(
         RiskAssessmentDataSourceMock.SUBMITTED_RISK_ASSESSMENT_ID,
+        2,
         2,
         1,
         2,
@@ -48,6 +51,7 @@ export class RiskAssessmentDataSourceMock implements RiskAssessmentDataSource {
     const newAssessment = new RiskAssessment(
       maxId + 1,
       args.proposalPk,
+      args.scheduledEventId,
       creatorId,
       2,
       RiskAssessmentStatus.DRAFT,
@@ -74,9 +78,17 @@ export class RiskAssessmentDataSourceMock implements RiskAssessmentDataSource {
       if (filter.proposalPk) {
         matchFilter = ra.proposalPk === filter.proposalPk;
       }
+      if (filter.scheduledEventId) {
+        matchFilter =
+          matchFilter && ra.scheduledEventId === filter.scheduledEventId;
+      }
 
       return matchFilter;
     });
+  }
+
+  getRiskAssessmentSamples(riskAssessmentId: number): Promise<Sample[]> {
+    throw new Error('Method not implemented.');
   }
 
   async updateRiskAssessment(

--- a/src/datasources/postgres/RiskAssessmentDataSource.ts
+++ b/src/datasources/postgres/RiskAssessmentDataSource.ts
@@ -1,21 +1,29 @@
+import { logger } from '@esss-swap/duo-logger';
+
 import { Rejection } from '../../models/Rejection';
 import { RiskAssessment } from '../../models/RiskAssessment';
+import { Sample } from '../../models/Sample';
 import { RiskAssessmentsFilter } from '../../queries/RiskAssessmentQueries';
 import { CreateRiskAssessmentArgs } from '../../resolvers/mutations/CreateRiskAssesssment';
 import { UpdateRiskAssessmentArgs } from '../../resolvers/mutations/UpdateRiskAssessmentMutation';
 import { RiskAssessmentDataSource } from '../RiskAssessmentDataSource';
 import { RiskAssessmentStatus } from './../../models/RiskAssessment';
 import database from './database';
-import { createRiskAssessmentObject, RiskAssessmentRecord } from './records';
+import {
+  createRiskAssessmentObject,
+  RiskAssessmentRecord,
+  createSampleObject,
+} from './records';
 
 class PostgresRiskAssessmentDataSource implements RiskAssessmentDataSource {
   async createRiskAssessment(
-    { proposalPk }: CreateRiskAssessmentArgs,
+    { proposalPk, scheduledEventId }: CreateRiskAssessmentArgs,
     creatorId: number
   ): Promise<RiskAssessment> {
     return database('risk_assessments')
       .insert({
         proposal_pk: proposalPk,
+        scheduled_event_id: scheduledEventId,
         creator_user_id: creatorId,
         status: RiskAssessmentStatus.DRAFT,
       })
@@ -38,13 +46,16 @@ class PostgresRiskAssessmentDataSource implements RiskAssessmentDataSource {
   async getRiskAssessments(
     filter: RiskAssessmentsFilter
   ): Promise<RiskAssessment[]> {
-    const { proposalPk, questionaryIds } = filter;
+    const { proposalPk, questionaryIds, scheduledEventId } = filter;
 
     return database('risk_assessments')
       .select('*')
       .modify((query) => {
         if (proposalPk) {
           query.where({ proposal_pk: proposalPk });
+        }
+        if (scheduledEventId) {
+          query.andWhere('scheduled_event_id', scheduledEventId);
         }
         if (questionaryIds) {
           query.whereIn('questionary_id', questionaryIds);
@@ -55,15 +66,75 @@ class PostgresRiskAssessmentDataSource implements RiskAssessmentDataSource {
       );
   }
 
+  async getRiskAssessmentSamples(riskAssessmentId: number): Promise<Sample[]> {
+    return database('risk_assessments_has_samples')
+      .where('risk_assessment_id', riskAssessmentId)
+      .leftJoin(
+        'samples',
+        'risk_assessments_has_samples.sample_id',
+        'samples.sample_id'
+      )
+      .select('samples.*')
+      .then((results) => results.map((record) => createSampleObject(record)));
+  }
+
   async updateRiskAssessment(
     args: UpdateRiskAssessmentArgs
-  ): Promise<RiskAssessment | Rejection> {
-    return database('risk_assessments')
-      .update({ questionary_id: args.questionaryId, status: args.status })
-      .where({ risk_assessment_id: args.riskAssessmentId })
-      .returning('*')
-      .then(async (riskAssessments) => {
-        return createRiskAssessmentObject(riskAssessments[0]);
+  ): Promise<RiskAssessment> {
+    const { riskAssessmentId, sampleIds, status, questionaryId } = args;
+
+    return database
+      .transaction(async (trx) => {
+        try {
+          if (sampleIds) {
+            await database('risk_assessments_has_samples')
+              .delete()
+              .where('risk_assessment_id', riskAssessmentId)
+              .transacting(trx);
+
+            if (sampleIds.length > 0) {
+              const rowsToInsert = sampleIds.map((sampleId) => ({
+                risk_assessment_id: riskAssessmentId,
+                sample_id: sampleId,
+              }));
+
+              await database('risk_assessments_has_samples')
+                .insert(rowsToInsert)
+                .transacting(trx);
+            }
+          }
+
+          if (questionaryId || status) {
+            await database('risk_assessments')
+              .update({ questionary_id: questionaryId, status: status })
+              .where({ risk_assessment_id: riskAssessmentId })
+              .returning('*')
+              .transacting(trx)
+              .then(async (riskAssessments) =>
+                createRiskAssessmentObject(riskAssessments[0])
+              );
+          }
+
+          return trx.commit();
+        } catch (error) {
+          logger.logError('Can not update risk assessment', {
+            msg: error.message,
+          });
+          trx.rollback();
+        }
+      })
+      .then(async () => {
+        const updatedRiskAssessment = await this.getRiskAssessment(
+          riskAssessmentId
+        );
+        if (updatedRiskAssessment === null) {
+          throw new Error('Could not update risk assessment');
+        }
+
+        return updatedRiskAssessment;
+      })
+      .catch((exception) => {
+        throw new Error('Could not update risk assessment');
       });
   }
 

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -512,6 +512,7 @@ export interface VisitRecord {
 export interface RiskAssessmentRecord {
   readonly risk_assessment_id: number;
   readonly proposal_pk: number;
+  readonly scheduled_event_id: number;
   readonly creator_user_id: number;
   readonly questionary_id: number;
   readonly status: string;
@@ -873,6 +874,7 @@ export const createRiskAssessmentObject = (
   return new RiskAssessment(
     riskAssessment.risk_assessment_id,
     riskAssessment.proposal_pk,
+    riskAssessment.scheduled_event_id,
     riskAssessment.creator_user_id,
     riskAssessment.questionary_id,
     (riskAssessment.status as any) as RiskAssessmentStatus,

--- a/src/models/RiskAssessment.ts
+++ b/src/models/RiskAssessment.ts
@@ -2,6 +2,7 @@ export class RiskAssessment {
   constructor(
     public riskAssessmentId: number,
     public proposalPk: number,
+    public scheduledEventId: number,
     public creatorUserId: number,
     public questionaryId: number,
     public status: RiskAssessmentStatus,

--- a/src/mutations/RiskAssessmentMutations.spec.ts
+++ b/src/mutations/RiskAssessmentMutations.spec.ts
@@ -23,13 +23,19 @@ beforeEach(() => {
 
 test('User should not be able to create risk assessment for not accepted proposal', async () => {
   return expect(
-    mutations.createRiskAssessment(dummyUserWithRole, { proposalPk: 1 })
+    mutations.createRiskAssessment(dummyUserWithRole, {
+      proposalPk: 1,
+      scheduledEventId: 1,
+    })
   ).resolves.toBeInstanceOf(Rejection);
 });
 
 test('User should be able to create risk assessment for accepted proposal', async () => {
   return expect(
-    mutations.createRiskAssessment(dummyUserWithRole, { proposalPk: 2 })
+    mutations.createRiskAssessment(dummyUserWithRole, {
+      proposalPk: 2,
+      scheduledEventId: 2,
+    })
   ).resolves.toBeInstanceOf(RiskAssessment);
 });
 
@@ -37,6 +43,7 @@ test('User not on proposal should not be able to create risk assessment', () => 
   return expect(
     mutations.createRiskAssessment(dummyUserNotOnProposalWithRole, {
       proposalPk: 2,
+      scheduledEventId: 2,
     })
   ).resolves.toBeInstanceOf(Rejection);
 });

--- a/src/mutations/RiskAssessmentMutations.ts
+++ b/src/mutations/RiskAssessmentMutations.ts
@@ -49,6 +49,8 @@ export default class RiskAssessmentMutations {
       );
     }
 
+    // TODO check if scheduled event ID exists
+
     if (
       proposal.finalStatus !== ProposalEndStatus.ACCEPTED ||
       proposal.managementDecisionSubmitted === false
@@ -85,7 +87,7 @@ export default class RiskAssessmentMutations {
       );
       if (!activeTemplate) {
         return rejection(
-          'Could not create visit registration questionary, because no active template for visit is set',
+          'Could not create visit registration questionary, because no active template for risk assessment is set',
           { args }
         );
       }
@@ -137,15 +139,13 @@ export default class RiskAssessmentMutations {
         { args, agent: user }
       );
     }
-
     try {
       return this.dataSource.updateRiskAssessment(args);
     } catch (error) {
-      return rejection(
-        'Could not update risk assessment because of an error',
-        { args },
-        error
-      );
+      return rejection('Could not update risk assessment', {
+        args: args,
+        error: error,
+      });
     }
   }
 

--- a/src/mutations/VisitMutations.ts
+++ b/src/mutations/VisitMutations.ts
@@ -11,7 +11,7 @@ import { rejection } from '../models/Rejection';
 import { Rejection } from '../models/Rejection';
 import { TemplateCategoryId } from '../models/Template';
 import { UserWithRole } from '../models/User';
-import { Visit, VisitStatus } from '../models/Visit';
+import { Visit } from '../models/Visit';
 import { VisitRegistration } from '../models/VisitRegistration';
 import { CreateVisitArgs } from '../resolvers/mutations/CreateVisitMutation';
 import { UpdateVisitArgs } from '../resolvers/mutations/UpdateVisitMutation';
@@ -134,15 +134,6 @@ export default class VisitMutations {
       return rejection(
         'Can not update visit because of insufficient permissions',
         { args, agent: user }
-      );
-    }
-
-    if (
-      args.status === VisitStatus.ACCEPTED &&
-      !this.userAuthorization.isUserOfficer(user)
-    ) {
-      return rejection(
-        'Can not update proposal status because of insufficient permissions'
       );
     }
 

--- a/src/mutations/VisitMutations.ts
+++ b/src/mutations/VisitMutations.ts
@@ -11,7 +11,7 @@ import { rejection } from '../models/Rejection';
 import { Rejection } from '../models/Rejection';
 import { TemplateCategoryId } from '../models/Template';
 import { UserWithRole } from '../models/User';
-import { Visit } from '../models/Visit';
+import { Visit, VisitStatus } from '../models/Visit';
 import { VisitRegistration } from '../models/VisitRegistration';
 import { CreateVisitArgs } from '../resolvers/mutations/CreateVisitMutation';
 import { UpdateVisitArgs } from '../resolvers/mutations/UpdateVisitMutation';
@@ -129,6 +129,15 @@ export default class VisitMutations {
     }
 
     const hasRights = await this.visitAuthorization.hasWriteRights(user, visit);
+
+    if (
+      this.userAuthorization.isUser(user) &&
+      args.status === VisitStatus.ACCEPTED
+    ) {
+      return rejection(
+        'Can not update visit status because of insufficient permissions'
+      );
+    }
 
     if (hasRights === false) {
       return rejection(

--- a/src/queries/RiskAssessmentQueries.ts
+++ b/src/queries/RiskAssessmentQueries.ts
@@ -10,6 +10,7 @@ import { RiskAssessmentAuthorization } from '../utils/RiskAssessmentAuthorizatio
 import { UserAuthorization } from './../utils/UserAuthorization';
 
 export interface RiskAssessmentsFilter {
+  scheduledEventId?: number;
   proposalPk?: number;
   questionaryIds?: number[];
 }
@@ -53,5 +54,18 @@ export default class RiskAssessmentQueries {
     ).then((results) => riskAssessments.filter((_v, index) => results[index]));
 
     return riskAssessments;
+  }
+
+  @Authorized()
+  async getSamples(agent: UserWithRole | null, riskAssessmentId: number) {
+    const hasRights = await this.riskAssessmentAuth.hasReadRights(
+      agent,
+      riskAssessmentId
+    );
+    if (hasRights === false) {
+      return [];
+    }
+
+    return this.dataSource.getRiskAssessmentSamples(riskAssessmentId);
   }
 }

--- a/src/resolvers/mutations/CreateRiskAssesssment.ts
+++ b/src/resolvers/mutations/CreateRiskAssesssment.ts
@@ -16,6 +16,9 @@ import { wrapResponse } from '../wrapResponse';
 export class CreateRiskAssessmentArgs {
   @Field(() => Int)
   proposalPk: number;
+
+  @Field(() => Int)
+  scheduledEventId: number;
 }
 
 @Resolver()

--- a/src/resolvers/mutations/UpdateRiskAssessmentMutation.ts
+++ b/src/resolvers/mutations/UpdateRiskAssessmentMutation.ts
@@ -21,6 +21,9 @@ export class UpdateRiskAssessmentArgs {
   @Field(() => RiskAssessmentStatus, { nullable: true })
   status?: RiskAssessmentStatus;
 
+  @Field(() => [Int], { nullable: true })
+  sampleIds?: number[];
+
   questionaryId?: number;
 }
 

--- a/src/resolvers/types/RiskAssessment.ts
+++ b/src/resolvers/types/RiskAssessment.ts
@@ -15,6 +15,7 @@ import {
 } from '../../models/RiskAssessment';
 import { TemplateCategoryId } from '../../models/Template';
 import { Questionary } from './Questionary';
+import { Sample } from './Sample';
 
 @ObjectType()
 export class RiskAssessment implements Partial<RiskAssessmentOrig> {
@@ -23,6 +24,9 @@ export class RiskAssessment implements Partial<RiskAssessmentOrig> {
 
   @Field(() => Int)
   public proposalPk: number;
+
+  @Field(() => Int)
+  public scheduledEventId: number;
 
   @Field(() => Int)
   public creatorUserId: number;
@@ -45,6 +49,17 @@ export class RiskAssessmentResolver {
       context.user,
       riskAssessment.questionaryId,
       TemplateCategoryId.PROPOSAL_QUESTIONARY
+    );
+  }
+
+  @FieldResolver(() => [Sample])
+  async samples(
+    @Root() riskAssessment: RiskAssessment,
+    @Ctx() context: ResolverContext
+  ): Promise<Sample[]> {
+    return context.queries.riskAssessment.getSamples(
+      context.user,
+      riskAssessment.riskAssessmentId
     );
   }
 }


### PR DESCRIPTION
## Description

This PR aims to fix the issue that there could be multiple risk assessments for experiments if there are multiple risk assessments. Each risk assessment should indicate which sample materials are the risk assessment for.


## How Has This Been Tested

Added E2E tests

## Fixes
https://jira.esss.lu.se/browse/SWAP-1731


## Depends on
https://github.com/UserOfficeProject/user-office-frontend/pull/524

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.