### PR TITLE
Improve user experience when cloning sample

### DIFF
--- a/src/mutations/SampleMutations.ts
+++ b/src/mutations/SampleMutations.ts
@@ -148,7 +148,11 @@ export default class SampleMutations {
   }
 
   @Authorized()
-  async cloneSample(agent: UserWithRole | null, sampleId: number) {
+  async cloneSample(
+    agent: UserWithRole | null,
+    sampleId: number,
+    title: string | undefined
+  ) {
     if (!agent) {
       return rejection(
         'Could not clone sample because user is not authorized',
@@ -166,7 +170,7 @@ export default class SampleMutations {
       let clonedSample = await this.sampleDataSource.cloneSample(sampleId);
       clonedSample = await this.sampleDataSource.updateSample({
         sampleId: clonedSample.id,
-        title: `Copy of ${clonedSample.title}`,
+        title: title ? title : `Copy of ${clonedSample.title}`,
       });
 
       return clonedSample;

--- a/src/mutations/SampleMutations.ts
+++ b/src/mutations/SampleMutations.ts
@@ -151,7 +151,7 @@ export default class SampleMutations {
   async cloneSample(
     agent: UserWithRole | null,
     sampleId: number,
-    title: string | undefined
+    title?: string
   ) {
     if (!agent) {
       return rejection(

--- a/src/resolvers/mutations/CloneSampleMutation.ts
+++ b/src/resolvers/mutations/CloneSampleMutation.ts
@@ -9,10 +9,11 @@ export class CloneSampleMutation {
   @Mutation(() => SampleResponseWrap)
   cloneSample(
     @Arg('sampleId', () => Int) sampleId: number,
+    @Arg('title', () => String, { nullable: true }) title: string | undefined,
     @Ctx() context: ResolverContext
   ) {
     return wrapResponse(
-      context.mutations.sample.cloneSample(context.user, sampleId),
+      context.mutations.sample.cloneSample(context.user, sampleId, title),
       SampleResponseWrap
     );
   }


### PR DESCRIPTION
## Description

This PR aims to improve the user experience when cloning sample
![Peek 2021-09-14 13-41](https://user-images.githubusercontent.com/58165815/133251435-02d18a83-a039-4bc1-be6d-ad83119fb920.gif)

## Motivation and Context

Currently, when cloning a sample it clones it with the title 'Copy of <original title>". Most often the user will then click the item to rename it.

With this change when the user wants to copy a sample the prompt is presented asking to enter the new title of the sample.

## How Has This Been Tested

-[x] E2E


## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/551

