### PR TITLE
Disable GraphQL Playground if in Production

### DIFF
--- a/src/middlewares/graphql.ts
+++ b/src/middlewares/graphql.ts
@@ -54,11 +54,10 @@ const apolloServer = async (app: Express) => {
   const server = new ApolloServer({
     schema: schema,
     tracing: false,
-    playground: {
-      settings: {
-        'schema.polling.enable': false,
-      },
-    },
+    // Explicitly disable playground in prod
+    playground: process.env.NODE_END !== 'production'
+      ? {settings: {'schema.polling.enable': false}}
+      : false,
     plugins: [ApolloServerPluginInlineTraceDisabled()],
 
     context: async ({ req }: { req: Req }) => {


### PR DESCRIPTION
## Description

'One line' change that keeps original config but otherwise explicitly sets playground to false if in production.
[Default behaviour](https://www.apollographql.com/docs/apollo-server/v2/testing/graphql-playground/) is that this should be disabled in production anyway -- I'm wondering if it was being enabled (even partially) by the explicit setting of `schema.polling.enable`. This should no longer occur.

## How Has This Been Tested

I've tested this by changing `production` to `development`, which disables the playground entirely in the local environment. I would expect the exact same behaviour on prod.  
The URL can still be pinged so this won't break the [prod backend monitoring job](https://ci.devs.facilities.rl.ac.uk/view/ProposalSubmission/job/Prod_Test.Ping_ProposalBackend/) -- this tested by running the exact same command there directed at `localhost:8081/graphql' instead. See screenshot below.
![image](https://user-images.githubusercontent.com/57662035/133102113-a72574e3-f215-498d-aab6-dbd015825cb0.png)

## Motivation and Context / Fixes

Fixes: https://github.com/UserOfficeProject/stfc-user-office-project/issues/193
