### PR TITLE
GraphQL Playground Issue Typo Correction

### DIFF
--- a/src/middlewares/graphql.ts
+++ b/src/middlewares/graphql.ts
@@ -55,7 +55,7 @@ const apolloServer = async (app: Express) => {
     schema: schema,
     tracing: false,
     // Explicitly disable playground in prod
-    playground: process.env.NODE_END !== 'production'
+    playground: process.env.NODE_ENV !== 'production'
       ? {settings: {'schema.polling.enable': false}}
       : false,
     plugins: [ApolloServerPluginInlineTraceDisabled()],


### PR DESCRIPTION
## Description

I missed a typo in my previous PR for this issue: `process.end.NODE_END` --> `process.end.NODE_ENV`.  
I have corrected this here.

## Context

Details otherwise match the [aforementioned PR](https://github.com/UserOfficeProject/user-office-backend/pull/407).