### PR TITLE
fix: Give instrument scientist role to user officers (and developers)

### DIFF
--- a/src/datasources/stfc/StfcUserDataSource.spec.ts
+++ b/src/datasources/stfc/StfcUserDataSource.spec.ts
@@ -31,7 +31,7 @@ test('When getting roles for a user, STFC roles are translated into ESS roles', 
     expect.arrayContaining([
       new Role(1, Roles.USER, 'User'),
       new Role(2, Roles.USER_OFFICER, 'User Officer'),
-      new Role(3, Roles.INSTRUMENT_SCIENTIST, 'ISIS Instrument Scientist'),
+      new Role(3, Roles.INSTRUMENT_SCIENTIST, 'Instrument Scientist'),
     ])
   );
 });


### PR DESCRIPTION
Refs https://github.com/UserOfficeProject/stfc-user-office-project/issues/208

## Description

Give instrument scientist role to user officers (and developers), allowing mapping from one-to-many for roles.. This also makes the code more explicit in what it's trying to achieve.

## Motivation and Context

Fixes https://github.com/UserOfficeProject/stfc-user-office-project/issues/208

## How Has This Been Tested

Tested using unit tests and running in frontend

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [x] All relevant doc has been updated
