### PR TITLE
Added div, br to allowed tags and allow all styles

### DIFF
--- a/src/models/questionTypes/RichTextInput.ts
+++ b/src/models/questionTypes/RichTextInput.ts
@@ -28,23 +28,15 @@ export const sanitizerConfig: IOptions = {
     'ul',
     'ol',
     'li',
+    'div',
+    'br',
   ],
   disallowedTagsMode: 'discard',
   allowedAttributes: {
     a: ['href', 'title'],
     span: ['style'],
     p: ['style'],
-  },
-  allowedStyles: {
-    '*': {
-      color: [
-        /^#(0x)?[0-9a-f]+$/i, // hex
-        /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i, // rgb
-      ],
-      'text-align': [/^left$/i, /^right$/i, /^center$/i, /^justify$/i],
-      'font-size': [/^\d+(?:px|em|%)$/i],
-      'text-decoration': [/^underline$/i, /^line-through$/i],
-    },
+    div: ['style'],
   },
   selfClosing: [],
   allowedSchemes: [],


### PR DESCRIPTION
## Description

sanitizeHtml was added for checking contents but was not allowing enough tags or styles to make sufficient HTML content. This allows more tags and also removes the check for what styles are allowed

## Motivation and Context

For user officer to be able to set HTML content with <div style="xxx"> 

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
