### PR TITLE
style: alter log format

### DIFF
--- a/src/eventHandlers/logging.ts
+++ b/src/eventHandlers/logging.ts
@@ -14,8 +14,8 @@ export default function createHandler() {
   // Handler that logs every mutation wrapped with the event bus event to stdout and event_logs table.
   return async function loggingHandler(event: ApplicationEvent) {
     const json = JSON.stringify(event);
-    const timestamp = new Date().toLocaleString();
-    console.log(`${timestamp} -- ${json}`);
+    const timestamp = new Date().toISOString();
+    console.log(`[${timestamp}] EVENT - ${json}`);
 
     // NOTE: If the event is rejection than log that in the database as well. Later we will be able to see all errors that happened.
     if (event.isRejection) {


### PR DESCRIPTION
## Description

This is an optional PR that alters the event logger format to mirror the console logger format

Before (from STFC log server):
![image](https://user-images.githubusercontent.com/14293717/143265357-2d4a0022-1ab9-47cb-8bc2-838081c3b09f.png)

After (local log output):
![image](https://user-images.githubusercontent.com/14293717/143265227-bbf6b14b-5a82-47bb-b66c-3e9e4c5bf65e.png)

## Motivation and Context

## How Has This Been Tested

Tested by checking local log output

## Fixes

Part of UserOfficeProject/stfc-user-office-project#272

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
