### PR TITLE
refactor: Use duo-logger instead of console in the backend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -71,6 +71,7 @@
       "error",
       { "blankLine": "always", "prev": "*", "next": "return" }
     ],
-    "unused-imports/no-unused-imports-ts": 2
+    "unused-imports/no-unused-imports-ts": 2,
+    "no-console": "error" // We should use `duo-logger` rather than `console` to log messages
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,10 @@ async function bootstrap() {
     logger.logException('Unhandled NODE exception', error);
   });
 
-  console.info(`Running a GraphQL API server at localhost:${PORT}/graphql`);
+  logger.logInfo(
+    `Running a GraphQL API server at localhost:${PORT}/graphql`,
+    {}
+  );
 
   startAsyncJobs();
   container.resolve<() => void>(Tokens.ConfigureEnvironment)();

--- a/src/eventHandlers/email.ts
+++ b/src/eventHandlers/email.ts
@@ -157,7 +157,10 @@ export default function createHandler() {
           await userDataSource.setUserEmailVerified(
             event.userlinkresponse.user.id
           );
-          console.log('verify user without email in development');
+          logger.logInfo('Set user as verified without sending email', {
+            userId: event.userlinkresponse.user.id,
+            event,
+          });
         } else {
           mailService
             .sendMail({

--- a/src/eventHandlers/logging.ts
+++ b/src/eventHandlers/logging.ts
@@ -11,11 +11,10 @@ export default function createHandler() {
     Tokens.EventLogsDataSource
   );
 
-  // Handler that logs every mutation wrapped with the event bus event to stdout and event_logs table.
+  // Handler that logs every mutation wrapped with the event bus event to logger and event_logs table.
   return async function loggingHandler(event: ApplicationEvent) {
     const json = JSON.stringify(event);
-    const timestamp = new Date().toLocaleString();
-    console.log(`${timestamp} -- ${json}`);
+    logger.logInfo('An event was triggered', { json });
 
     // NOTE: If the event is rejection than log that in the database as well. Later we will be able to see all errors that happened.
     if (event.isRejection) {

--- a/src/factory/service.ts
+++ b/src/factory/service.ts
@@ -29,7 +29,10 @@ export type XLSXMetaBase = MetaBase & { columns: string[] };
 const ENDPOINT = process.env.USER_OFFICE_FACTORY_ENDPOINT;
 
 if (!ENDPOINT) {
-  console.error('`USER_OFFICE_FACTORY_ENDPOINT` is missing');
+  logger.logError(
+    'Could not start application: the `USER_OFFICE_FACTORY_ENDPOINT` environment variable is missing. Exiting.',
+    {}
+  );
   process.exit(1);
 }
 

--- a/src/middlewares/factory/pdf.ts
+++ b/src/middlewares/factory/pdf.ts
@@ -19,8 +19,6 @@ router.get(`/${PDFType.PROPOSAL}/:proposal_pks`, async (req, res, next) => {
       currentRole: req.user.currentRole,
     };
 
-    console.log(userWithRole);
-
     const proposalPks: number[] = req.params.proposal_pks
       .split(',')
       .map((n: string) => parseInt(n))

--- a/src/populate/executor.ts
+++ b/src/populate/executor.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 export async function execute<T>(f: () => Promise<T>, count: number) {
   const results: Array<T> = [];
   for (let index = 0; index < count; index++) {

--- a/src/populate/index.ts
+++ b/src/populate/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import 'dotenv/config';
 
 import faker from 'faker';

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,3 +1,4 @@
+import { logger } from '@esss-swap/duo-logger';
 import jsonwebtoken, {
   Algorithm,
   SignOptions,
@@ -8,12 +9,18 @@ const secret = process.env.secret as string;
 const expiresIn = process.env.tokenLife as string;
 
 if (!secret) {
-  console.error('jwt secret missing');
+  logger.logError(
+    'Could not start application: the `secret` environment variable is missing. Exiting.',
+    {}
+  );
   process.exit(1);
 }
 
 if (!expiresIn) {
-  console.error('tokenLife missing');
+  logger.logError(
+    'Could not start application: the `tokenLike` environment variable is missing. Exiting.',
+    {}
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
Loosely related to UserOfficeProject/stfc-user-office-project#231

## Description
Replaces all `console.log()` occurrences with calls to `duo-logger`.

The PR also introduces a new ESLint rule to avoid using `console.log()` in the future. Some developer scripts have been excluded from this new rule as it's not relevant for them.

Originally done as part of UserOfficeProject/stfc-user-office-project#231, I'm creating a separate PR as the main issue is blocked by not being able to push to NPM.

## Motivation and Context
Using duo-logger for all messages ensures that all log output is formatted in the same way, allowing us to parse and monitor it with tools like Elasticsearch.

It also makes it easier to see where messages are being logged, and to replace the default logger if necessary.

## How Has This Been Tested
Checking the logs for relevant events on my local machine.

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
