### PR TITLE
Upgrade packages to align with scheduler backend versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,26 @@
   "requires": true,
   "dependencies": {
     "@apollo/federation": {
-      "version": "0.33.7",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.7.tgz",
-      "integrity": "sha512-sUIyJUdgni5DivFo8AeqMtaArqDTLh6ItXxYZb1LxhPXPhD1n8tnO8Vp50aS8SslKtmGUcm+eyUvkc3ZxRxiIg==",
+      "version": "0.33.8",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.8.tgz",
+      "integrity": "sha512-sgf0t8S7rzrlz9uJxp3ZKhkpub7QpmfbrEV3Lj0YFlUXlACEJU4p8tqz9bh4VyqSuy0ayl026BYTDFtRvlJTKg==",
       "requires": {
-        "@apollo/subgraph": "^0.1.4",
-        "apollo-graphql": "^0.9.3",
+        "@apollo/subgraph": "^0.1.5",
+        "apollo-graphql": "^0.9.5",
         "apollo-server-types": "^3.0.2",
         "lodash.xorby": "^4.7.0"
+      },
+      "dependencies": {
+        "apollo-graphql": {
+          "version": "0.9.5",
+          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.5.tgz",
+          "integrity": "sha512-RGt5k2JeBqrmnwRM0VOgWFiGKlGJMfmiif/4JvdaEqhMJ+xqe/9cfDYzXfn33ke2eWixsAbjEbRfy8XbaN9nTw==",
+          "requires": {
+            "core-js-pure": "^3.10.2",
+            "lodash.sortby": "^4.7.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@apollo/protobufjs": {
@@ -43,11 +55,23 @@
       }
     },
     "@apollo/subgraph": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-0.1.4.tgz",
-      "integrity": "sha512-G1N/sXZIHeX27tf+7lefEwVZFNYzdARe+pD597U5opfM1Gs1mYwRySfOdm1QkcItYG+EmTcSOuUJ5bNbvW0IUg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-0.1.5.tgz",
+      "integrity": "sha512-i1uU9llldGMV7GcBOUQRqnbGfgOpc6nrOVw93oKlugZq5R00q8y/RX8KgvMfdXZyr4MJ2/gO6Kw7LzbjCKU+Kw==",
       "requires": {
-        "apollo-graphql": "^0.9.3"
+        "apollo-graphql": "^0.9.5"
+      },
+      "dependencies": {
+        "apollo-graphql": {
+          "version": "0.9.5",
+          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.5.tgz",
+          "integrity": "sha512-RGt5k2JeBqrmnwRM0VOgWFiGKlGJMfmiif/4JvdaEqhMJ+xqe/9cfDYzXfn33ke2eWixsAbjEbRfy8XbaN9nTw==",
+          "requires": {
+            "core-js-pure": "^3.10.2",
+            "lodash.sortby": "^4.7.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@apollographql/apollo-tools": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@apollo/federation": "^0.33.7",
-    "@apollo/subgraph": "^0.1.4",
+    "@apollo/federation": "^0.33.8",
+    "@apollo/subgraph": "^0.1.5",
     "@esss-swap/duo-localisation": "^1.1.15",
     "@esss-swap/duo-logger": "^1.1.1",
     "@esss-swap/duo-message-broker": "^1.0.8",

--- a/src/utils/buildFederatedSchema.ts
+++ b/src/utils/buildFederatedSchema.ts
@@ -1,6 +1,5 @@
-import { buildSubgraphSchema } from '@apollo/federation';
-import { printSubgraphSchema } from '@apollo/subgraph';
-import { federationDirectives } from '@apollo/subgraph/dist/directives';
+import { printSubgraphSchema, buildSubgraphSchema } from '@apollo/subgraph';
+import { knownSubgraphDirectives } from '@apollo/subgraph/dist/directives';
 import { addResolversToSchema, GraphQLResolverMap } from 'apollo-graphql';
 import { specifiedDirectives } from 'graphql';
 import gql from 'graphql-tag';
@@ -20,7 +19,7 @@ export async function buildFederatedSchema(
     ...options,
     directives: [
       ...specifiedDirectives,
-      ...federationDirectives,
+      ...knownSubgraphDirectives,
       ...(options.directives || []),
     ],
     skipCheck: true,


### PR DESCRIPTION
## Description

Upgrade some of the `@apollo` packages to align with `user-office-scheduler-backend`. Also fixed some errors after upgrading the `@apollo/subgraph`.

## Motivation and Context

Its better to keep both backends aligned with dependencies to avoid some incompatibilities on the gateway.
