### PR TITLE
fix(eam): Month in JS is 0-based but in C# 1-based

### DIFF
--- a/src/services/eam/requests/AddAssetEquipment.ts
+++ b/src/services/eam/requests/AddAssetEquipment.ts
@@ -53,7 +53,9 @@ const getRequest = (
 				</DEPARTMENTID>
 				<COMMISSIONDATE qualifier="ACCOUNTING" xmlns="http://schemas.datastream.net/MP_fields">
 					<YEAR xmlns="http://www.openapplications.org/oagis_fields">${date.getUTCFullYear()}</YEAR>
-					<MONTH xmlns="http://www.openapplications.org/oagis_fields">${date.getUTCMonth()}</MONTH>
+					<MONTH xmlns="http://www.openapplications.org/oagis_fields">${
+            date.getUTCMonth() + 1 // +1 because getUTCMonth returns 0-11
+          }</MONTH>
 					<DAY xmlns="http://www.openapplications.org/oagis_fields">${date.getUTCDay()}</DAY>
 					<HOUR xmlns="http://www.openapplications.org/oagis_fields">${date.getUTCHours()}</HOUR>
 					<MINUTE xmlns="http://www.openapplications.org/oagis_fields">${date.getUTCMinutes()}</MINUTE>

--- a/src/services/eam/requests/AddCaseManagement.ts
+++ b/src/services/eam/requests/AddCaseManagement.ts
@@ -69,7 +69,9 @@ const getRequest = (
         <TrackingDetails>          
           <DATEREQUESTED qualifier="ACCOUNTING" xmlns="http://schemas.datastream.net/MP_fields">
             <YEAR xmlns="http://www.openapplications.org/oagis_fields">${dateRequested.getFullYear()}</YEAR>
-            <MONTH xmlns="http://www.openapplications.org/oagis_fields">${dateRequested.getMonth()}</MONTH>
+            <MONTH xmlns="http://www.openapplications.org/oagis_fields">${
+              dateRequested.getMonth() + 1 // month is zero-based
+            }</MONTH>
             <DAY xmlns="http://www.openapplications.org/oagis_fields">${dateRequested.getDay()}</DAY>
             <HOUR xmlns="http://www.openapplications.org/oagis_fields">${dateRequested.getHours()}</HOUR>
             <MINUTE xmlns="http://www.openapplications.org/oagis_fields">${dateRequested.getMinutes()}</MINUTE>
@@ -87,7 +89,9 @@ const getRequest = (
           <EMAIL xmlns="http://schemas.datastream.net/MP_fields">nagaman.singh@ess.eu</EMAIL>         
           <SCHEDULEDSTARTDATE qualifier="ACCOUNTING" xmlns="http://schemas.datastream.net/MP_fields">
           <YEAR xmlns="http://www.openapplications.org/oagis_fields">${experimentStartDate.getFullYear()}</YEAR>
-          <MONTH xmlns="http://www.openapplications.org/oagis_fields">${experimentStartDate.getMonth()}</MONTH>
+          <MONTH xmlns="http://www.openapplications.org/oagis_fields">${
+            experimentStartDate.getMonth() + 1 // month is zero-based
+          }</MONTH>
           <DAY xmlns="http://www.openapplications.org/oagis_fields">${experimentStartDate.getDay()}</DAY>
           <HOUR xmlns="http://www.openapplications.org/oagis_fields">${experimentStartDate.getHours()}</HOUR>
           <MINUTE xmlns="http://www.openapplications.org/oagis_fields">${experimentStartDate.getMinutes()}</MINUTE>
@@ -97,7 +101,9 @@ const getRequest = (
           </SCHEDULEDSTARTDATE>
           <SCHEDULEDENDDATE qualifier="ACCOUNTING" xmlns="http://schemas.datastream.net/MP_fields">
           <YEAR xmlns="http://www.openapplications.org/oagis_fields">${experimentEndDate.getFullYear()}</YEAR>
-          <MONTH xmlns="http://www.openapplications.org/oagis_fields">${experimentEndDate.getMonth()}</MONTH>
+          <MONTH xmlns="http://www.openapplications.org/oagis_fields">${
+            experimentEndDate.getMonth() + 1 // month is zero-based
+          }</MONTH>
           <DAY xmlns="http://www.openapplications.org/oagis_fields">${experimentEndDate.getDay()}</DAY>
           <HOUR xmlns="http://www.openapplications.org/oagis_fields">${experimentEndDate.getHours()}</HOUR>
           <MINUTE xmlns="http://www.openapplications.org/oagis_fields">${experimentEndDate.getMinutes()}</MINUTE>


### PR DESCRIPTION
Closes SWAP-2160

## Description

Month in JS is 0-based but in C# 1 based, this caused an inconsistency

## Motivation and Context

In January creating new containers and issues in EAM started to fail

## How Has This Been Tested

- [x] Manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2160

## Changes

EAM requests

## Depends on

N/A
