### PR TITLE
fix(scheduled-event): renaming scheduledEvent to scheduledEventCore

### DIFF
--- a/src/auth/EsiAuthorization.ts
+++ b/src/auth/EsiAuthorization.ts
@@ -20,7 +20,7 @@ export class EsiAuthorization {
   ) {}
 
   getScheduledEvent = async (scheduledEventId: number) =>
-    await this.scheduledEventDataSource.getScheduledEvent(scheduledEventId);
+    await this.scheduledEventDataSource.getScheduledEventCore(scheduledEventId);
 
   private async resolveEsi(
     esiOrEsiId: ExperimentSafetyInput | number

--- a/src/datasources/ScheduledEventDataSource.ts
+++ b/src/datasources/ScheduledEventDataSource.ts
@@ -1,9 +1,9 @@
 import { ScheduledEventCore } from '../models/ScheduledEventCore';
-import { ScheduledEventsFilter } from '../resolvers/queries/ScheduledEventsQuery';
+import { ScheduledEventsCoreFilter } from '../resolvers/queries/ScheduledEventsCoreQuery';
 
 export interface ScheduledEventDataSource {
-  getScheduledEvents(
-    filter: ScheduledEventsFilter
+  getScheduledEventsCore(
+    filter: ScheduledEventsCoreFilter
   ): Promise<ScheduledEventCore[]>;
-  getScheduledEvent(id: number): Promise<ScheduledEventCore | null>;
+  getScheduledEventCore(id: number): Promise<ScheduledEventCore | null>;
 }

--- a/src/datasources/mockups/ScheduledEventDataSource.ts
+++ b/src/datasources/mockups/ScheduledEventDataSource.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 import { ScheduledEventCore } from '../../models/ScheduledEventCore';
-import { ScheduledEventsFilter } from '../../resolvers/queries/ScheduledEventsQuery';
+import { ScheduledEventsCoreFilter } from '../../resolvers/queries/ScheduledEventsCoreQuery';
 import { ScheduledEventDataSource } from '../ScheduledEventDataSource';
 import {
   ScheduledEventBookingType,
@@ -63,12 +63,12 @@ export default class ScheduledEventDataSourceMock
     ];
   }
 
-  async getScheduledEvent(id: number): Promise<ScheduledEventCore | null> {
+  async getScheduledEventCore(id: number): Promise<ScheduledEventCore | null> {
     return this.scheduledEvents.find((esi) => esi.id === id) || null;
   }
 
-  async getScheduledEvents(
-    filter: ScheduledEventsFilter
+  async getScheduledEventsCore(
+    filter: ScheduledEventsCoreFilter
   ): Promise<ScheduledEventCore[]> {
     return this.scheduledEvents
       .filter((esi) => {

--- a/src/datasources/postgres/ScheduledEventDataSource.ts
+++ b/src/datasources/postgres/ScheduledEventDataSource.ts
@@ -1,5 +1,5 @@
 import { ScheduledEventCore } from '../../models/ScheduledEventCore';
-import { ScheduledEventsFilter } from '../../resolvers/queries/ScheduledEventsQuery';
+import { ScheduledEventsCoreFilter } from '../../resolvers/queries/ScheduledEventsCoreQuery';
 import { ScheduledEventDataSource } from '../ScheduledEventDataSource';
 import database from './database';
 import { createScheduledEventObject, ScheduledEventRecord } from './records';
@@ -8,7 +8,7 @@ export default class PostgresScheduledEventDataSource
   implements ScheduledEventDataSource
 {
   async getScheduledEventsCore(
-    filter: ScheduledEventsFilter
+    filter: ScheduledEventsCoreFilter
   ): Promise<ScheduledEventCore[]> {
     return database
       .select('*')

--- a/src/datasources/postgres/ScheduledEventDataSource.ts
+++ b/src/datasources/postgres/ScheduledEventDataSource.ts
@@ -7,7 +7,7 @@ import { createScheduledEventObject, ScheduledEventRecord } from './records';
 export default class PostgresScheduledEventDataSource
   implements ScheduledEventDataSource
 {
-  async getScheduledEvents(
+  async getScheduledEventsCore(
     filter: ScheduledEventsFilter
   ): Promise<ScheduledEventCore[]> {
     return database
@@ -25,7 +25,7 @@ export default class PostgresScheduledEventDataSource
         rows.map((row) => createScheduledEventObject(row))
       );
   }
-  async getScheduledEvent(id: number): Promise<ScheduledEventCore | null> {
+  async getScheduledEventCore(id: number): Promise<ScheduledEventCore | null> {
     return database
       .select('*')
       .from('scheduled_events')

--- a/src/mutations/FeedbackMutations.ts
+++ b/src/mutations/FeedbackMutations.ts
@@ -69,7 +69,7 @@ export default class FeedbackMutations {
     }
 
     const scheduledEvent =
-      await this.scheduledEventDataSource.getScheduledEvent(
+      await this.scheduledEventDataSource.getScheduledEventCore(
         args.scheduledEventId
       );
     if (!scheduledEvent) {
@@ -274,7 +274,9 @@ export default class FeedbackMutations {
   ): Promise<FeedbackRequest | Rejection> {
     // Check if scheduled event exists
     const scheduledEvent =
-      await this.scheduledEventDataSource.getScheduledEvent(scheduledEventId);
+      await this.scheduledEventDataSource.getScheduledEventCore(
+        scheduledEventId
+      );
     if (!scheduledEvent) {
       return rejection(
         'Can not create feedback because scheduled event does not exist',

--- a/src/mutations/ProposalEsiMutations.ts
+++ b/src/mutations/ProposalEsiMutations.ts
@@ -38,7 +38,9 @@ export default class ProposalEsiMutations {
     scheduledEventId: number
   ): Promise<ExperimentSafetyInput | Rejection> {
     const scheduledEvent =
-      await this.scheduledEventDataSource.getScheduledEvent(scheduledEventId);
+      await this.scheduledEventDataSource.getScheduledEventCore(
+        scheduledEventId
+      );
     if (!scheduledEvent?.proposalPk) {
       return rejection(
         'Can not create ESI, because scheduled event does not exist or has no proposal attached to it'

--- a/src/mutations/VisitMutations.ts
+++ b/src/mutations/VisitMutations.ts
@@ -60,7 +60,7 @@ export default class VisitMutations {
     }
 
     const scheduledEvent =
-      await this.scheduledEventDataSource.getScheduledEvent(
+      await this.scheduledEventDataSource.getScheduledEventCore(
         args.scheduledEventId
       );
     if (!scheduledEvent) {

--- a/src/queries/ScheduledEventQueries.ts
+++ b/src/queries/ScheduledEventQueries.ts
@@ -5,7 +5,7 @@ import { ScheduledEventDataSource } from '../datasources/ScheduledEventDataSourc
 import { Authorized } from '../decorators';
 import { Roles } from '../models/Role';
 import { UserWithRole } from '../models/User';
-import { ScheduledEventsFilter } from './../resolvers/queries/ScheduledEventsQuery';
+import { ScheduledEventsCoreFilter } from '../resolvers/queries/ScheduledEventsCoreQuery';
 import { ScheduledEventCore } from './../resolvers/types/ScheduledEvent';
 
 @injectable()
@@ -16,11 +16,13 @@ export default class ScheduledEventQueries {
   ) {}
 
   @Authorized([Roles.USER_OFFICER])
-  async getScheduledEvents(
+  async getScheduledEventsCore(
     user: UserWithRole | null,
-    filter: ScheduledEventsFilter
+    filter: ScheduledEventsCoreFilter
   ): Promise<ScheduledEventCore[]> {
-    const scheduledEvents = await this.dataSource.getScheduledEvents(filter);
+    const scheduledEvents = await this.dataSource.getScheduledEventsCore(
+      filter
+    );
 
     return scheduledEvents;
   }

--- a/src/resolvers/queries/ScheduledEventsCoreQuery.ts
+++ b/src/resolvers/queries/ScheduledEventsCoreQuery.ts
@@ -5,7 +5,7 @@ import { TzLessDateTime } from '../CustomScalars';
 import { ScheduledEventCore } from '../types/ScheduledEvent';
 
 @ArgsType()
-export class ScheduledEventsFilter {
+export class ScheduledEventsCoreFilter {
   @Field(() => TzLessDateTime, { nullable: true })
   endsBefore?: Date;
 
@@ -14,13 +14,13 @@ export class ScheduledEventsFilter {
 }
 
 @Resolver()
-export class ScheduledEventsQuery {
+export class ScheduledEventsCoreQuery {
   @Query(() => [ScheduledEventCore], { nullable: true })
-  async scheduledEvents(
-    @Args() filter: ScheduledEventsFilter,
+  async scheduledEventsCore(
+    @Args() filter: ScheduledEventsCoreFilter,
     @Ctx() context: ResolverContext
   ): Promise<ScheduledEventCore[] | null> {
-    return context.queries.scheduledEvent.getScheduledEvents(
+    return context.queries.scheduledEvent.getScheduledEventsCore(
       context.user,
       filter
     );

--- a/src/resolvers/types/ExperimentSafetyInput.ts
+++ b/src/resolvers/types/ExperimentSafetyInput.ts
@@ -72,7 +72,7 @@ export class ExperimentSafetyInputResolver {
       container.resolve<ScheduledEventDataSource>(
         Tokens.ScheduledEventDataSource
       );
-    const scheduledEvent = await scheduledEventDataSource.getScheduledEvent(
+    const scheduledEvent = await scheduledEventDataSource.getScheduledEventCore(
       esi.scheduledEventId
     );
     if (scheduledEvent === null || scheduledEvent.proposalPk === null) {

--- a/src/services/eam/index.ts
+++ b/src/services/eam/index.ts
@@ -109,7 +109,7 @@ export class EAMAssetRegistrar implements AssetRegistrar {
     }
 
     const scheduledEvent =
-      await this.scheduledEventDataSource.getScheduledEvent(
+      await this.scheduledEventDataSource.getScheduledEventCore(
         shipment.scheduledEventId
       );
     if (!scheduledEvent) {


### PR DESCRIPTION
## Description

This is to avoid conflicts in naming between core and scheduler

## Motivation and Context

When using Apollo Federation, endpoint names must not clash.
There was a clashing query named ScheduledEvent

