### PR TITLE
Run dev Docker container as Node user

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM node:16.13-alpine
 
+USER node
+
 # The Git repo should be mounted from the host into this directory
 WORKDIR /app
 


### PR DESCRIPTION
Part of UserOfficeProject/stfc-user-office-project#313

## Description

On Node 16, running as root can cause NPM to fail due to permission errors. It's safer to run as a non-root user.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
