### PR TITLE
fix: instrument sci unable to filter by question

### DIFF
--- a/src/datasources/stfc/StfcProposalDataSource.ts
+++ b/src/datasources/stfc/StfcProposalDataSource.ts
@@ -65,7 +65,7 @@ export default class StfcProposalDataSource extends PostgresProposalDataSource {
             .leftJoin(
               'answers',
               'answers.questionary_id',
-              'proposals.questionary_id'
+              'proposal_table_view.questionary_id'
             )
             .andWhere('answers.question_id', questionFilter.questionId)
             .modify(questionFilterQuery, questionFilter);


### PR DESCRIPTION
## Description
Closes: https://github.com/UserOfficeProject/stfc-user-office-project/issues/318
<!--- Describe your changes in detail -->

## Motivation and Context
Instrument scientist unable to filter by question 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested through logging on as a Instrument Scientist and using the question filters.
![image](https://user-images.githubusercontent.com/72739242/150564814-3dc109fe-d70f-4710-b56b-34b9cda93656.png)

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
fixes: https://github.com/UserOfficeProject/stfc-user-office-project/issues/318
## Changes
File changed: `StfcProposalDataSource.ts`
<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
