### PR TITLE
fix: add more logs to verify user error

### DIFF
--- a/src/mutations/UserMutations.ts
+++ b/src/mutations/UserMutations.ts
@@ -552,7 +552,7 @@ export default class UserMutations {
 
         return true;
       } else {
-        return rejection('Can not verify user', { user });
+        return rejection('Can not verify user', { user, decoded });
       }
     } catch (error) {
       return rejection('Can not verify email', {}, error);


### PR DESCRIPTION
## Description

Currently, there is incomplete information about the error when it happens. This PR will add more details to the 'can not verify user' error log