### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @UserOfficeProject/stfc-user-programme


### PR DESCRIPTION
Stopping STFC User Programme from being made codeowners on all PRs.