### PR TITLE
fix: Allow users to verify email after user update to avoid false error messages

### DIFF
--- a/src/mutations/UserMutations.ts
+++ b/src/mutations/UserMutations.ts
@@ -542,12 +542,8 @@ export default class UserMutations {
     try {
       const decoded = verifyToken<EmailVerificationJwtPayload>(token);
       const user = await this.dataSource.getUser(decoded.id);
-      //Check that user exist and that it has not been updated since token creation
-      if (
-        user &&
-        user.updated === decoded.updated &&
-        decoded.type === 'emailVerification'
-      ) {
+      //Check that user exist
+      if (user && decoded.type === 'emailVerification') {
         await this.dataSource.setUserEmailVerified(user.id);
 
         return true;
@@ -555,7 +551,11 @@ export default class UserMutations {
         return rejection('Can not verify user', { user, decoded });
       }
     } catch (error) {
-      return rejection('Can not verify email', {}, error);
+      return rejection(
+        'Can not verify email, please contact user office for help',
+        {},
+        error
+      );
     }
   }
 


### PR DESCRIPTION
## Description

When a user tried to verify a email it would fail if the user record had already been updated after the verify token had been created, this would lead to false errors as email clients tried visiting the verify url again. This PR allows a verify to happen multiple times and after the user record has been updated

## Motivation and Context

Remove false positives

## How Has This Been Tested

Locally
