### PR TITLE
Allow querying by refrence numbers

### DIFF
--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -389,6 +389,9 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
             `proposals.proposal_id similar to '%(${filteredAndPreparedShortCodes})%'`
           );
         }
+        if (filter?.referenceNumbers) {
+          query.whereIn('reference_number_sequence', filter.referenceNumbers);
+        }
 
         if (first) {
           query.limit(first);

--- a/src/resolvers/queries/ProposalsQuery.ts
+++ b/src/resolvers/queries/ProposalsQuery.ts
@@ -52,6 +52,9 @@ export class ProposalsFilter {
 
   @Field(() => QuestionFilterInput, { nullable: true })
   public questionFilter?: QuestionFilterInput;
+
+  @Field(() => [String], { nullable: true })
+  public referenceNumbers?: string[];
 }
 
 @ArgsType()


### PR DESCRIPTION
## Description
Allows querying proposals by reference numbers

<!--- Describe your changes in detail -->
Add reference numbers to proposal filter

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Tested in playground

## Fixes
closes [UserOfficeProject/user-office-issue-tracker#336](https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/336)

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
