### PR TITLE
fix: remove alarming message

### DIFF
--- a/src/eventHandlers/messageBroker.ts
+++ b/src/eventHandlers/messageBroker.ts
@@ -147,11 +147,6 @@ export function createPostToRabbitMQHandler() {
           proposalStatus?.shortCode !==
           ProposalStatusDefaultShortCodes.SCHEDULING
         ) {
-          logger.logDebug(
-            `Proposal '${proposal.primaryKey}' status isn't 'SCHEDULING', skipping`,
-            { proposal, proposalStatus }
-          );
-
           return;
         }
 


### PR DESCRIPTION
## Description

Removing a debug message that caused confusion and alarm

## Motivation and Context

We want to be alarmed about issues that we need to look at. Even though this was a debug message this has caused quiet of alarm when happening in production however there is no need to worry in these scenarios when the debug message was logged.

## Fixes

https://jira.esss.lu.se/browse/SWAP-2232

## Changes

- messageBrokker

## Depends on

N/A

