### PR TITLE
fix: add new page

### DIFF
--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -6,4 +6,5 @@ export enum PageName {
   REVIEWPAGE = 5,
   FOOTERCONTENT = 6,
   LOGINHELPPAGE = 7,
+  GRADEGUIDEPAGE = 8,
 }


### PR DESCRIPTION
## Description

This PR adds a help page that can be opened when grading a proposal to guide the grader into the process

## Motivation and Context

Different users have different views on the meaning of the number behind the grade. That could make the average grade distorted based on the reviewer's particular style of grading. Therefore there should always be a guide on how to grade at hand.


## Fixes

https://jira.esss.lu.se/browse/SWAP-1516

## Changes

Added new page and link to it

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/826


