### PR TITLE
fix: SEP reviewer should only read/write reviews he/she can review

### DIFF
--- a/src/auth/ProposalAuthorization.ts
+++ b/src/auth/ProposalAuthorization.ts
@@ -110,12 +110,8 @@ export class ProposalAuthorization {
 
     const sepIdsUserIsMemberOf = sepsUserIsMemberOf.map((sep) => sep.id);
 
-    /**
-     * NOTE: Everybody who is on a(member of) SEP(Scientific evaluation panel) is able to view and review a proposal.
-     * If we like to limit that we can just send userId on the getUserReviews and query for reviews that are only on that specific user.
-     */
     return this.reviewDataSource
-      .getUserReviews(sepIdsUserIsMemberOf)
+      .getUserReviews(sepIdsUserIsMemberOf, agent.id)
       .then((reviews) => {
         return reviews.some((review) => review.proposalPk === proposalPk);
       });

--- a/src/auth/ReviewAuthorization.ts
+++ b/src/auth/ReviewAuthorization.ts
@@ -1,0 +1,120 @@
+import { container, inject, injectable } from 'tsyringe';
+
+import { Tokens } from '../config/Tokens';
+import { ReviewDataSource } from '../datasources/ReviewDataSource';
+import { ReviewStatus } from '../models/Review';
+import { UserWithRole } from '../models/User';
+import { Review } from '../resolvers/types/Review';
+import { ProposalAuthorization } from './ProposalAuthorization';
+import { UserAuthorization } from './UserAuthorization';
+
+@injectable()
+export class ReviewAuthorization {
+  private proposalAuth = container.resolve(ProposalAuthorization);
+  private userAuth = container.resolve(UserAuthorization);
+  constructor(
+    @inject(Tokens.ReviewDataSource)
+    private reviewDataSource: ReviewDataSource
+  ) {}
+
+  private async resolveReview(
+    reviewOrReviewId: Review | number
+  ): Promise<Review | null> {
+    let review;
+
+    if (typeof reviewOrReviewId === 'number') {
+      review = await this.reviewDataSource.getReview(reviewOrReviewId);
+    } else {
+      review = reviewOrReviewId;
+    }
+
+    return review;
+  }
+
+  async hasReadRights(
+    agent: UserWithRole | null,
+    review: Review
+  ): Promise<boolean>;
+  async hasReadRights(
+    agent: UserWithRole | null,
+    reviewId: number
+  ): Promise<boolean>;
+  async hasReadRights(
+    agent: UserWithRole | null,
+    reviewOrReviewId: Review | number
+  ): Promise<boolean> {
+    const review = await this.resolveReview(reviewOrReviewId);
+    if (!review) {
+      return false;
+    }
+
+    const isUserOfficer = await this.userAuth.isUserOfficer(agent);
+    if (isUserOfficer) {
+      return true;
+    }
+
+    const isAuthor = review.userID === agent?.id;
+    if (isAuthor) {
+      return true;
+    }
+
+    const isChairOrSecretaryOfSEP = await this.userAuth.isChairOrSecretaryOfSEP(
+      agent,
+      review.sepID
+    );
+    if (isChairOrSecretaryOfSEP) {
+      return true;
+    }
+
+    const isReviewerOfProposal = await this.proposalAuth.isReviewerOfProposal(
+      agent,
+      review.proposalPk
+    );
+    if (isReviewerOfProposal) {
+      return true;
+    }
+
+    return false;
+  }
+
+  async hasWriteRights(
+    agent: UserWithRole | null,
+    review: Review
+  ): Promise<boolean>;
+  async hasWriteRights(
+    agent: UserWithRole | null,
+    reviewId: number
+  ): Promise<boolean>;
+  async hasWriteRights(
+    agent: UserWithRole | null,
+    reviewOrReviewId: Review | number
+  ): Promise<boolean> {
+    const review = await this.resolveReview(reviewOrReviewId);
+    if (!review) {
+      return false;
+    }
+
+    const isUserOfficer = await this.userAuth.isUserOfficer(agent);
+    if (isUserOfficer) {
+      return true;
+    }
+
+    const isChairOrSecretaryOfSEP = await this.userAuth.isChairOrSecretaryOfSEP(
+      agent,
+      review.sepID
+    );
+    if (isChairOrSecretaryOfSEP) {
+      return true;
+    }
+
+    const isReviewerOfProposal = await this.proposalAuth.isReviewerOfProposal(
+      agent,
+      review.proposalPk
+    );
+    if (isReviewerOfProposal && review.status !== ReviewStatus.SUBMITTED) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/auth/TechnicalReviewAuthorization.ts
+++ b/src/auth/TechnicalReviewAuthorization.ts
@@ -1,0 +1,137 @@
+import { container, inject, injectable } from 'tsyringe';
+
+import { Tokens } from '../config/Tokens';
+import { ReviewDataSource } from '../datasources/ReviewDataSource';
+import { UserWithRole } from '../models/User';
+import { TechnicalReview } from '../resolvers/types/TechnicalReview';
+import { ProposalAuthorization } from './ProposalAuthorization';
+import { UserAuthorization } from './UserAuthorization';
+
+@injectable()
+export class TechnicalReviewAuthorization {
+  private proposalAuth = container.resolve(ProposalAuthorization);
+  private userAuth = container.resolve(UserAuthorization);
+  constructor(
+    @inject(Tokens.ReviewDataSource)
+    private reviewDataSource: ReviewDataSource
+  ) {}
+
+  private async resolveTechnicalReview(
+    technicalreviewOrProposalPk: TechnicalReview | number
+  ): Promise<TechnicalReview | null> {
+    let technicalreview;
+
+    if (typeof technicalreviewOrProposalPk === 'number') {
+      const proposalPk = technicalreviewOrProposalPk;
+      technicalreview = await this.reviewDataSource.getTechnicalReview(
+        proposalPk
+      );
+    } else {
+      technicalreview = technicalreviewOrProposalPk;
+    }
+
+    return technicalreview;
+  }
+
+  async hasReadRights(
+    agent: UserWithRole | null,
+    technicalreview: TechnicalReview
+  ): Promise<boolean>;
+  async hasReadRights(
+    agent: UserWithRole | null,
+    technicalreviewId: number
+  ): Promise<boolean>;
+  async hasReadRights(
+    agent: UserWithRole | null,
+    technicalreviewOrTechnicalReviewId: TechnicalReview | number
+  ): Promise<boolean> {
+    if (this.userAuth.isUserOfficer(agent)) {
+      return true;
+    }
+
+    const technicalreview = await this.resolveTechnicalReview(
+      technicalreviewOrTechnicalReviewId
+    );
+    if (!technicalreview) {
+      return false;
+    }
+
+    const isScientistToProposal = await this.proposalAuth.isScientistToProposal(
+      agent,
+      technicalreview.proposalPk
+    );
+    if (isScientistToProposal) {
+      return true;
+    }
+
+    const isChairOrSecretaryOfProposal =
+      await this.proposalAuth.isChairOrSecretaryOfProposal(
+        agent,
+        technicalreview.proposalPk
+      );
+    if (isChairOrSecretaryOfProposal) {
+      return true;
+    }
+
+    const isReviewerOfProposal = await this.proposalAuth.isReviewerOfProposal(
+      agent,
+      technicalreview.proposalPk
+    );
+    if (isReviewerOfProposal) {
+      return true;
+    }
+
+    return false;
+  }
+
+  async hasWriteRights(
+    agent: UserWithRole | null,
+    technicalreview: TechnicalReview
+  ): Promise<boolean>;
+  async hasWriteRights(
+    agent: UserWithRole | null,
+    technicalreviewId: number
+  ): Promise<boolean>;
+  async hasWriteRights(
+    agent: UserWithRole | null,
+    technicalreviewOrTechnicalReviewId: TechnicalReview | number
+  ): Promise<boolean> {
+    if (this.userAuth.isUserOfficer(agent)) {
+      return true;
+    }
+
+    const technicalreview = await this.resolveTechnicalReview(
+      technicalreviewOrTechnicalReviewId
+    );
+    if (!technicalreview) {
+      return false;
+    }
+
+    const isScientistToProposal = await this.proposalAuth.isScientistToProposal(
+      agent,
+      technicalreview.proposalPk
+    );
+    if (isScientistToProposal) {
+      return true;
+    }
+
+    const isChairOrSecretaryOfProposal =
+      await this.proposalAuth.isChairOrSecretaryOfProposal(
+        agent,
+        technicalreview.proposalPk
+      );
+    if (isChairOrSecretaryOfProposal) {
+      return true;
+    }
+
+    const isReviewerOfProposal = await this.proposalAuth.isReviewerOfProposal(
+      agent,
+      technicalreview.proposalPk
+    );
+    if (isReviewerOfProposal && technicalreview.submitted === false) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/auth/TechnicalReviewAuthorization.ts
+++ b/src/auth/TechnicalReviewAuthorization.ts
@@ -45,15 +45,16 @@ export class TechnicalReviewAuthorization {
     agent: UserWithRole | null,
     technicalreviewOrTechnicalReviewId: TechnicalReview | number
   ): Promise<boolean> {
-    if (this.userAuth.isUserOfficer(agent)) {
-      return true;
-    }
-
     const technicalreview = await this.resolveTechnicalReview(
       technicalreviewOrTechnicalReviewId
     );
     if (!technicalreview) {
       return false;
+    }
+
+    const isUserOfficer = await this.userAuth.isUserOfficer(agent);
+    if (isUserOfficer) {
+      return true;
     }
 
     const isScientistToProposal = await this.proposalAuth.isScientistToProposal(

--- a/src/mutations/ReviewMutations.ts
+++ b/src/mutations/ReviewMutations.ts
@@ -6,6 +6,8 @@ import {
 import { container, inject, injectable } from 'tsyringe';
 
 import { ProposalAuthorization } from '../auth/ProposalAuthorization';
+import { ReviewAuthorization } from '../auth/ReviewAuthorization';
+import { TechnicalReviewAuthorization } from '../auth/TechnicalReviewAuthorization';
 import { UserAuthorization } from '../auth/UserAuthorization';
 import { Tokens } from '../config/Tokens';
 import { ProposalDataSource } from '../datasources/ProposalDataSource';
@@ -33,6 +35,8 @@ import { checkAllReviewsSubmittedOnProposal } from '../utils/helperFunctions';
 
 @injectable()
 export default class ReviewMutations {
+  private technicalReviewAuth = container.resolve(TechnicalReviewAuthorization);
+  private reviewAuth = container.resolve(ReviewAuthorization);
   private userAuth = container.resolve(UserAuthorization);
   private proposalAuth = container.resolve(ProposalAuthorization);
 
@@ -60,33 +64,11 @@ export default class ReviewMutations {
       });
     }
 
-    const isChairOrSecretaryOfSEP = await this.userAuth.isChairOrSecretaryOfSEP(
-      agent,
-      review.sepID
-    );
+    const hasWriteRights = await this.reviewAuth.hasWriteRights(agent, review);
 
-    if (
-      !(
-        (await this.proposalAuth.isReviewerOfProposal(
-          agent,
-          review.proposalPk
-        )) ||
-        isChairOrSecretaryOfSEP ||
-        this.userAuth.isUserOfficer(agent)
-      )
-    ) {
+    if (!hasWriteRights) {
       return rejection(
         'Can not update review because of insufficient permissions',
-        { agent, args }
-      );
-    }
-
-    if (
-      review.status === ReviewStatus.SUBMITTED &&
-      !(this.userAuth.isUserOfficer(agent) || isChairOrSecretaryOfSEP)
-    ) {
-      return rejection(
-        'Can not update review because review already submitted',
         { agent, args }
       );
     }
@@ -158,28 +140,10 @@ export default class ReviewMutations {
       );
     }
 
-    if (
-      !(
-        (await this.proposalAuth.isReviewerOfProposal(
-          agent,
-          review.proposalPk
-        )) ||
-        (await this.userAuth.isChairOrSecretaryOfSEP(agent, review.sepID)) ||
-        this.userAuth.isUserOfficer(agent)
-      )
-    ) {
+    const hasWriteRights = await this.reviewAuth.hasWriteRights(agent, review);
+    if (!hasWriteRights) {
       return rejection(
-        'Can not submit proposal review because of insufficient premissions',
-        { agent, args }
-      );
-    }
-
-    if (
-      review.status === ReviewStatus.SUBMITTED &&
-      !this.userAuth.isUserOfficer(agent)
-    ) {
-      return rejection(
-        'Can not submit proposal review because review already submitted',
+        'Can not submit proposal review because of insufficient permissions',
         { agent, args }
       );
     }
@@ -209,30 +173,29 @@ export default class ReviewMutations {
     agent: UserWithRole | null,
     args: AddTechnicalReviewInput | SubmitTechnicalReviewInput
   ): Promise<TechnicalReview | Rejection> {
-    if (
-      !(
-        this.userAuth.isUserOfficer(agent) ||
-        (await this.proposalAuth.isScientistToProposal(agent, args.proposalPk))
-      )
-    ) {
+    const technicalReview = await this.dataSource.getTechnicalReview(
+      args.proposalPk
+    );
+
+    if (!technicalReview) {
+      return rejection(
+        'Can not set technical review because technical review was not found',
+        { args }
+      );
+    }
+
+    const hasWriteRights = await this.technicalReviewAuth.hasWriteRights(
+      agent,
+      technicalReview
+    );
+    if (!hasWriteRights) {
       return rejection(
         'Can not set technical review because of insufficient permissions',
         { agent, args }
       );
     }
 
-    const technicalReview = await this.dataSource.getTechnicalReview(
-      args.proposalPk
-    );
-
     const shouldUpdateReview = !!technicalReview?.id;
-
-    if (!this.userAuth.isUserOfficer(agent) && technicalReview?.submitted) {
-      return rejection(
-        'Can not set technical review because review already submitted',
-        { agent, args }
-      );
-    }
 
     if (args.reviewerId !== undefined && args.reviewerId !== agent?.id) {
       return rejection('Request is impersonating another user', {

--- a/src/mutations/ReviewMutations.ts
+++ b/src/mutations/ReviewMutations.ts
@@ -173,20 +173,9 @@ export default class ReviewMutations {
     agent: UserWithRole | null,
     args: AddTechnicalReviewInput | SubmitTechnicalReviewInput
   ): Promise<TechnicalReview | Rejection> {
-    const technicalReview = await this.dataSource.getTechnicalReview(
-      args.proposalPk
-    );
-
-    if (!technicalReview) {
-      return rejection(
-        'Can not set technical review because technical review was not found',
-        { args }
-      );
-    }
-
     const hasWriteRights = await this.technicalReviewAuth.hasWriteRights(
       agent,
-      technicalReview
+      args.proposalPk
     );
     if (!hasWriteRights) {
       return rejection(
@@ -195,7 +184,12 @@ export default class ReviewMutations {
       );
     }
 
-    const shouldUpdateReview = !!technicalReview?.id;
+    const technicalReview = await this.dataSource.getTechnicalReview(
+      args.proposalPk
+    );
+    const technicalReviewExists = technicalReview !== null;
+
+    const shouldUpdateReview = technicalReviewExists ? true : false;
 
     if (args.reviewerId !== undefined && args.reviewerId !== agent?.id) {
       return rejection('Request is impersonating another user', {

--- a/src/resolvers/queries/ReviewQuery.ts
+++ b/src/resolvers/queries/ReviewQuery.ts
@@ -8,10 +8,9 @@ export class ReviewQuery {
   @Query(() => Review, { nullable: true })
   review(
     @Arg('reviewId', () => Int) reviewId: number,
-    @Arg('sepId', () => Int, { nullable: true }) sepId: number | null,
     @Ctx() context: ResolverContext
   ) {
-    return context.queries.review.get(context.user, { reviewId, sepId });
+    return context.queries.review.get(context.user, { reviewId });
   }
 
   @Query(() => [Review], { nullable: true })


### PR DESCRIPTION
## Description
This PR refactors and fixes review authorization


## Motivation and Context
This PR 
- moves authorization into ReviewAuthorizer and TechnicalReviewAuhtorizer components, and then reuses the logic in mutations
- allows read/write rights to only those reviewers who have been assigned to do the review/technicalReview



## How Has This Been Tested
- [x] E2E
- [x] Manual tests


## Fixes

https://jira.esss.lu.se/browse/SWAP-2480

## Changes
- Added authorizers
- Changed corresponding to use Authorizers

## Depends on

https://github.com/UserOfficeProject/user-office-frontend/pull/842


