### PR TITLE
fix: remove DB limit for review comment

### DIFF
--- a/db_patches/0119_AlterCommentInputDataType.sql
+++ b/db_patches/0119_AlterCommentInputDataType.sql
@@ -1,0 +1,14 @@
+DO
+$DO$
+BEGIN
+	IF register_patch('AlterCommentInputDataType.sql', 'Jekabs Karklins', 'Altering SEP review comment datatype', '2022-04-07') THEN
+    BEGIN
+      
+
+      ALTER TABLE "SEP_Reviews" ALTER COLUMN comment TYPE text;
+
+    END;
+	END IF;
+END;
+$DO$
+LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

remove DB limit for review comment

## Motivation and Context

Currently Reviewer is only allowed to enter 500 characters. This should not be limited.
New TEXT will allow to enter up to 65,535


## Fixes

https://jira.esss.lu.se/browse/SWAP-2492

## Changes

DB patch

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->

