### PR TITLE
Added option for different rabbitmq vhost

### DIFF
--- a/src/eventHandlers/messageBroker.ts
+++ b/src/eventHandlers/messageBroker.ts
@@ -44,6 +44,7 @@ const createRabbitMQMessageBroker = () => {
     hostname: process.env.RABBITMQ_HOSTNAME,
     username: process.env.RABBITMQ_USERNAME,
     password: process.env.RABBITMQ_PASSWORD,
+    vhost: process.env.RABBITMQ_VIRTUAL_HOST ?? '/',
   });
 
   return messageBroker;


### PR DESCRIPTION
Refs: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/519

## Description

At stfc were using a different vhost for rabbitmq so we need a way to set that in the backend.

If the vhost variable is not set the default value is used.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on
https://github.com/isisbusapps/docker-orchestration/pull/237
BisAppSettings: stfc-user-office-project-519-rabbitmq-prod-config

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
