### PR TITLE
fix: Use null instead of 0 for sep proposals call filtering when we want to query all calls

### DIFF
--- a/src/datasources/SEPDataSource.ts
+++ b/src/datasources/SEPDataSource.ts
@@ -50,7 +50,7 @@ export interface SEPDataSource {
     proposalPk: number,
     reviewerId: number | null
   ): Promise<SEPAssignment[]>;
-  getSEPProposals(sepId: number, callId: number): Promise<SEPProposal[]>;
+  getSEPProposals(sepId: number, callId: number | null): Promise<SEPProposal[]>;
   getSEPProposal(
     sepId: number,
     proposalPk: number

--- a/src/datasources/mockups/SEPDataSource.ts
+++ b/src/datasources/mockups/SEPDataSource.ts
@@ -281,7 +281,7 @@ export class SEPDataSourceMock implements SEPDataSource {
     return { totalCount: dummySEPsCopy.length, seps: dummySEPsCopy };
   }
 
-  async getSEPProposals(sepId: number, callId: number) {
+  async getSEPProposals(sepId: number, callId: number | null) {
     return dummySEPProposals.filter((proposal) => proposal.sepId === sepId);
   }
 

--- a/src/datasources/postgres/SEPDataSource.ts
+++ b/src/datasources/postgres/SEPDataSource.ts
@@ -225,7 +225,10 @@ export default class PostgresSEPDataSource implements SEPDataSource {
     );
   }
 
-  async getSEPProposals(sepId: number, callId: number): Promise<SEPProposal[]> {
+  async getSEPProposals(
+    sepId: number,
+    callId: number | null
+  ): Promise<SEPProposal[]> {
     const sepProposals: SEPProposalRecord[] = await database
       .select(['sp.*'])
       .from('SEP_Proposals as sp')

--- a/src/queries/SEPQueries.ts
+++ b/src/queries/SEPQueries.ts
@@ -55,7 +55,7 @@ export default class SEPQueries {
   @Authorized([Roles.USER_OFFICER, Roles.SEP_CHAIR, Roles.SEP_SECRETARY])
   async getSEPProposals(
     agent: UserWithRole | null,
-    { sepId, callId }: { sepId: number; callId: number }
+    { sepId, callId }: { sepId: number; callId: number | null }
   ) {
     if (
       this.userAuth.isUserOfficer(agent) ||

--- a/src/resolvers/queries/SEPQuery.ts
+++ b/src/resolvers/queries/SEPQuery.ts
@@ -34,7 +34,7 @@ export class SEPQuery {
   @Query(() => [SEPProposal], { nullable: true })
   async sepProposals(
     @Arg('sepId', () => Int) sepId: number,
-    @Arg('callId', () => Int) callId: number,
+    @Arg('callId', () => Int, { nullable: true }) callId: number | null,
     @Ctx() context: ResolverContext
   ): Promise<SEPProposal[] | null> {
     return context.queries.sep.getSEPProposals(context.user, { sepId, callId });


### PR DESCRIPTION
## Description

Using null which is much more understandable than 0 for loading all sep proposals when filtering by call.

## Motivation and Context

Previously we were sending 0 from the frontend as a callId in the filter which wasn't that clear.

## How Has This Been Tested

- e2e tests
- manual testing

## Fixes

https://jira.esss.lu.se/browse/SWAP-2467

## Changes

https://user-images.githubusercontent.com/6333063/163117850-a61de3d8-9acd-40bd-ad2c-b9ea219152bf.mp4

## Depends on

Frontend PR: https://github.com/UserOfficeProject/user-office-frontend/pull/856

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
