### PR TITLE
feat: Remove access for SEP chair and secretary to un-submit or change submitted reviews

### DIFF
--- a/src/auth/ReviewAuthorization.ts
+++ b/src/auth/ReviewAuthorization.ts
@@ -83,22 +83,16 @@ export class ReviewAuthorization {
   ): Promise<boolean>;
   async hasWriteRights(
     agent: UserWithRole | null,
-    reviewId: number,
-    reviewAlreadySubmitted?: boolean
-  ): Promise<boolean>;
-  async hasWriteRights(
-    agent: UserWithRole | null,
-    reviewOrReviewId: Review | number,
+    review: Review,
     reviewAlreadySubmitted = false
   ): Promise<boolean> {
-    const review = await this.resolveReview(reviewOrReviewId);
-    if (!review) {
-      return false;
-    }
-
     const isUserOfficer = this.userAuth.isUserOfficer(agent);
     if (isUserOfficer) {
       return true;
+    }
+
+    if (reviewAlreadySubmitted) {
+      return false;
     }
 
     const isChairOrSecretaryOfSEP = await this.userAuth.isChairOrSecretaryOfSEP(
@@ -113,7 +107,7 @@ export class ReviewAuthorization {
       agent,
       review.proposalPk
     );
-    if (isReviewerOfProposal && !reviewAlreadySubmitted) {
+    if (isReviewerOfProposal) {
       return true;
     }
 

--- a/src/auth/ReviewAuthorization.ts
+++ b/src/auth/ReviewAuthorization.ts
@@ -79,18 +79,20 @@ export class ReviewAuthorization {
 
   async hasWriteRights(
     agent: UserWithRole | null,
-    review: Review
+    review: Review,
+    canSubmitReview?: boolean
   ): Promise<boolean>;
   async hasWriteRights(
     agent: UserWithRole | null,
-    review: Review
+    review: Review,
+    canSubmitReview = false
   ): Promise<boolean> {
     const isUserOfficer = this.userAuth.isUserOfficer(agent);
     if (isUserOfficer) {
       return true;
     }
 
-    if (review.status === ReviewStatus.SUBMITTED) {
+    if (review.status === ReviewStatus.SUBMITTED && !canSubmitReview) {
       return false;
     }
 

--- a/src/auth/ReviewAuthorization.ts
+++ b/src/auth/ReviewAuthorization.ts
@@ -2,6 +2,7 @@ import { container, inject, injectable } from 'tsyringe';
 
 import { Tokens } from '../config/Tokens';
 import { ReviewDataSource } from '../datasources/ReviewDataSource';
+import { ReviewStatus } from '../models/Review';
 import { UserWithRole } from '../models/User';
 import { Review } from '../resolvers/types/Review';
 import { ProposalAuthorization } from './ProposalAuthorization';
@@ -78,20 +79,18 @@ export class ReviewAuthorization {
 
   async hasWriteRights(
     agent: UserWithRole | null,
-    review: Review,
-    reviewAlreadySubmitted?: boolean
+    review: Review
   ): Promise<boolean>;
   async hasWriteRights(
     agent: UserWithRole | null,
-    review: Review,
-    reviewAlreadySubmitted = false
+    review: Review
   ): Promise<boolean> {
     const isUserOfficer = this.userAuth.isUserOfficer(agent);
     if (isUserOfficer) {
       return true;
     }
 
-    if (reviewAlreadySubmitted) {
+    if (review.status === ReviewStatus.SUBMITTED) {
       return false;
     }
 

--- a/src/datasources/mockups/ReviewDataSource.ts
+++ b/src/datasources/mockups/ReviewDataSource.ts
@@ -6,6 +6,15 @@ import { UpdateReviewArgs } from '../../resolvers/mutations/UpdateReviewMutation
 import { ReviewDataSource } from '../ReviewDataSource';
 
 export const dummyReview = new Review(4, 10, 1, 'Good proposal', 9, 0, 1);
+export const dummySubmittedReview = new Review(
+  5,
+  10,
+  1,
+  'Good proposal',
+  9,
+  1,
+  1
+);
 export const dummyReviewWithNextProposalStatus =
   new ReviewWithNextProposalStatus(4, 10, 1, 'Good proposal', 9, 0, 1, null);
 
@@ -30,8 +39,12 @@ export class ReviewDataSourceMock implements ReviewDataSource {
     return new Review(1, 1, 1, ' ', 1, 1, 1);
   }
   async getReview(id: number): Promise<Review | null> {
-    if (id == 1) {
+    if (id === 1) {
       return dummyReviewBad;
+    }
+
+    if (id === 5) {
+      return dummySubmittedReview;
     }
 
     return dummyReview;

--- a/src/datasources/mockups/UserDataSource.ts
+++ b/src/datasources/mockups/UserDataSource.ts
@@ -102,6 +102,11 @@ export const dummySEPChairWithRole: UserWithRole = {
   currentRole: { id: 4, title: 'SEP Chair', shortCode: 'sep_chair' },
 };
 
+export const dummySEPSecretaryWithRole: UserWithRole = {
+  ...dummyUser,
+  currentRole: { id: 5, title: 'SEP Secretary', shortCode: 'sep_secretary' },
+};
+
 export const dummySampleReviewer: UserWithRole = {
   ...dummyUser,
   currentRole: {

--- a/src/mutations/ReviewMutations.spec.ts
+++ b/src/mutations/ReviewMutations.spec.ts
@@ -3,6 +3,8 @@ import { container } from 'tsyringe';
 
 import { dummyReviewWithNextProposalStatus } from '../datasources/mockups/ReviewDataSource';
 import {
+  dummySEPChairWithRole,
+  dummySEPSecretaryWithRole,
   dummyUserNotOnProposalWithRole,
   dummyUserOfficerWithRole,
   dummyUserWithRole,
@@ -33,6 +35,36 @@ test('A user can not submit a review on a proposal', () => {
       comment: 'Good proposal',
       grade: 9,
       status: ReviewStatus.DRAFT,
+      sepID: 1,
+    })
+  ).resolves.toHaveProperty(
+    'reason',
+    'Can not update review because of insufficient permissions'
+  );
+});
+
+test('A SEP chair can not modify SEP review if it is submitted', () => {
+  return expect(
+    reviewMutations.updateReview(dummySEPChairWithRole, {
+      reviewID: 5,
+      comment: 'Good proposal test',
+      grade: 9,
+      status: ReviewStatus.SUBMITTED,
+      sepID: 1,
+    })
+  ).resolves.toHaveProperty(
+    'reason',
+    'Can not update review because of insufficient permissions'
+  );
+});
+
+test('A SEP secretary can not modify SEP review if it is submitted', () => {
+  return expect(
+    reviewMutations.updateReview(dummySEPSecretaryWithRole, {
+      reviewID: 5,
+      comment: 'Good proposal test',
+      grade: 9,
+      status: ReviewStatus.SUBMITTED,
       sepID: 1,
     })
   ).resolves.toHaveProperty(

--- a/src/mutations/ReviewMutations.ts
+++ b/src/mutations/ReviewMutations.ts
@@ -141,7 +141,14 @@ export default class ReviewMutations {
       );
     }
 
-    const hasWriteRights = await this.reviewAuth.hasWriteRights(agent, review);
+    // NOTE: This is added for bulk submit where reviewer should be able to submit even already submitted reviews.
+    const canSubmitAlreadySubmittedReview = true;
+
+    const hasWriteRights = await this.reviewAuth.hasWriteRights(
+      agent,
+      review,
+      canSubmitAlreadySubmittedReview
+    );
     if (!hasWriteRights) {
       return rejection(
         'Can not submit proposal review because of insufficient permissions',

--- a/src/mutations/ReviewMutations.ts
+++ b/src/mutations/ReviewMutations.ts
@@ -65,12 +65,7 @@ export default class ReviewMutations {
       });
     }
 
-    const reviewAlreadySubmitted = review.status === ReviewStatus.SUBMITTED;
-    const hasWriteRights = await this.reviewAuth.hasWriteRights(
-      agent,
-      review,
-      reviewAlreadySubmitted
-    );
+    const hasWriteRights = await this.reviewAuth.hasWriteRights(agent, review);
 
     if (!hasWriteRights) {
       return rejection(


### PR DESCRIPTION
## Description

SEP Chair and SEP Secretary should not be able to change already submitted reviews and can not un-submit as well.

## Motivation and Context

Previously SEP Chair and Secretary were allowed to do any action on the SEP reviews.

## How Has This Been Tested

- manual tests
- unit tests
- e2e tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2474

## Depends on

Frontend PR: https://github.com/UserOfficeProject/user-office-frontend/pull/873

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
