### PR TITLE
fix: Fixing possible race condition when calling resetDB

### DIFF
--- a/src/mutations/AdminMutations.ts
+++ b/src/mutations/AdminMutations.ts
@@ -39,7 +39,9 @@ export default class AdminMutations {
       logger.logWarn('Resetting database', {});
 
       const log = await this.dataSource.resetDB(includeSeeds);
-      container.resolve<() => void>(Tokens.ConfigureEnvironment)();
+      await container.resolve<() => Promise<void>>(
+        Tokens.ConfigureEnvironment
+      )();
 
       return log;
     } else {


### PR DESCRIPTION
## Description

When getting or trying to mutate some data right after the `resetDB` call we were getting errors all the time because call finishes before setting up the environment properly. This was because we were not waiting for environment configure to finish.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2444

## Depends on

Frontend PR: https://github.com/UserOfficeProject/user-office-frontend/pull/875

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
