### PR TITLE
fix: adding reason why query error happened

### DIFF
--- a/src/datasources/postgres/database.ts
+++ b/src/datasources/postgres/database.ts
@@ -18,7 +18,12 @@ const db = Knex({
 });
 
 db.on('query-error', function (error: any, obj: any) {
-  logger.logError('QUERY ERROR', { error, obj, QueryName: obj?.sql });
+  logger.logError('QUERY ERROR', {
+    message: error?.message,
+    error,
+    obj,
+    QueryName: obj?.sql,
+  });
 });
 
 if (process.env.DATABASE_LOG_QUERIES === '1') {


### PR DESCRIPTION
## Description

This PR adds an error message to Query Error logs. This is an important message for debugging as it contains the actual reason for the failure. It appears that some properties are not stringified (including `message`) from the error object.
![image](https://user-images.githubusercontent.com/58165815/165761261-7a7bab86-7c72-4368-b989-4d5bafcdc82f.png)


## Motivation and Context

We want clear error messages so that we can see the reason what is causing it

## How Has This Been Tested

- [x] Manual tests


## Changes

database.ts

## Depends on

N/A


