### PR TITLE
fix: This PR fixes dangling references in question_dependencies

### DIFF
--- a/db_patches/0120_AddQuestionDependenciesOnDeleteCascade.sql
+++ b/db_patches/0120_AddQuestionDependenciesOnDeleteCascade.sql
@@ -1,0 +1,33 @@
+DO
+$DO$
+BEGIN
+	IF register_patch('AddQuestionDependenciesOnDeleteCascade.sql', 'Jekabs Karklins', 'Add question dependency on delete cascade', '2022-04-29') THEN
+    BEGIN
+      
+      -- Remove dangling references in question_dependencies from question_id  when question deleted
+      ALTER TABLE question_dependencies
+      DROP CONSTRAINT question_dependencies_question_id_fkey,
+                      ADD CONSTRAINT question_dependencies_question_id_fkey
+      FOREIGN KEY (question_id) REFERENCES questions (question_id) MATCH SIMPLE
+      ON DELETE CASCADE;
+
+
+      -- Remove dangling references in question_dependencies from dependency_question_id when question deleted
+      ALTER TABLE question_dependencies
+      DROP CONSTRAINT question_dependencies_dependency_question_id_fkey,
+                      ADD CONSTRAINT question_dependencies_dependency_question_id_fkey
+      FOREIGN KEY (dependency_question_id) REFERENCES questions (question_id) MATCH SIMPLE
+      ON DELETE CASCADE;
+
+      -- Remove dangling references in question_dependencies from dependency_question_id templates_has_questions deleted
+      ALTER TABLE question_dependencies
+        ADD CONSTRAINT question_dependencies_template_id_question_id_fkey
+        FOREIGN KEY  (template_id, question_id) 
+        REFERENCES templates_has_questions (template_id, question_id)
+        ON DELETE CASCADE;
+
+    END;
+	END IF;
+END;
+$DO$
+LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

This PR adds DB cleanups to make sure there are no dangling references to relations that does not exist

## Motivation and Context

the dependencies between questions should be cleaned up when:
 - the question is removed from the template;
 - the question is deleted


## How Has This Been Tested

- [x] Manual tests


## Changes

Added DB patch

