### PR TITLE
fix: mark default template after import

### DIFF
--- a/src/mutations/TemplateMutations.ts
+++ b/src/mutations/TemplateMutations.ts
@@ -484,10 +484,23 @@ export default class TemplateMutations {
     conflictResolution: ConflictResolution[]
   ): Promise<Template | Rejection> {
     try {
-      return await this.dataSource.importTemplate(
+      const template = await this.dataSource.importTemplate(
         templateAsJson,
         conflictResolution
       );
+
+      const currentActiveTemplateId = await this.dataSource.getActiveTemplateId(
+        template.groupId
+      );
+      if (!currentActiveTemplateId) {
+        // if there is no active template, then mark newly created template as active
+        await this.dataSource.setActiveTemplate({
+          templateGroupId: template.groupId,
+          templateId: template.templateId,
+        });
+      }
+
+      return template;
     } catch (error) {
       return rejection(
         'Could not import template',


### PR DESCRIPTION
## Description

Mark template as active after import, if there is no active template already

## Motivation and Context

As a user officer I expect the template to be set up right away after the import


## Depends on

N/A


