### PR TITLE
feat: Add proposals count to SEPs and SEP members

### DIFF
--- a/src/datasources/SEPDataSource.ts
+++ b/src/datasources/SEPDataSource.ts
@@ -51,6 +51,8 @@ export interface SEPDataSource {
     reviewerId: number | null
   ): Promise<SEPAssignment[]>;
   getSEPProposals(sepId: number, callId: number | null): Promise<SEPProposal[]>;
+  getSEPProposalCount(sepId: number): Promise<number>;
+  getSEPReviewerProposalCount(reviewerId: number): Promise<number>;
   getSEPProposal(
     sepId: number,
     proposalPk: number

--- a/src/datasources/mockups/SEPDataSource.ts
+++ b/src/datasources/mockups/SEPDataSource.ts
@@ -285,6 +285,14 @@ export class SEPDataSourceMock implements SEPDataSource {
     return dummySEPProposals.filter((proposal) => proposal.sepId === sepId);
   }
 
+  async getSEPProposalCount(sepId: number) {
+    return dummySEPProposals.length;
+  }
+
+  async getSEPReviewerProposalCount(reviewerId: number) {
+    return dummySEPProposals.length;
+  }
+
   async getSEPProposalsByInstrument(
     sepId: number,
     instrumentId: number,

--- a/src/datasources/postgres/SEPDataSource.ts
+++ b/src/datasources/postgres/SEPDataSource.ts
@@ -255,6 +255,26 @@ export default class PostgresSEPDataSource implements SEPDataSource {
     );
   }
 
+  async getSEPProposalCount(sepId: number): Promise<number> {
+    return database('SEP_Proposals')
+      .count('sep_id')
+      .where('sep_id', sepId)
+      .first()
+      .then((result: { count?: string | undefined } | undefined) => {
+        return parseInt(result?.count || '0');
+      });
+  }
+
+  async getSEPReviewerProposalCount(reviewerId: number): Promise<number> {
+    return database('SEP_Reviews')
+      .count('user_id')
+      .where('user_id', reviewerId)
+      .first()
+      .then((result: { count?: string | undefined } | undefined) => {
+        return parseInt(result?.count || '0');
+      });
+  }
+
   async getSEPProposal(
     sepId: number,
     proposalPk: number

--- a/src/resolvers/types/SEP.ts
+++ b/src/resolvers/types/SEP.ts
@@ -45,6 +45,20 @@ export class SEPResolvers {
     return context.queries.user.getBasic(context.user, sep.sepChairUserId);
   }
 
+  @FieldResolver(() => Int, { nullable: true })
+  async sepChairProposalCount(
+    @Root() sep: SEP,
+    @Ctx() context: ResolverContext
+  ) {
+    if (!sep.sepChairUserId) {
+      return null;
+    }
+
+    return context.queries.sep.dataSource.getSEPReviewerProposalCount(
+      sep.sepChairUserId
+    );
+  }
+
   @FieldResolver(() => BasicUserDetails, { nullable: true })
   async sepSecretary(@Root() sep: SEP, @Ctx() context: ResolverContext) {
     if (!sep.sepSecretaryUserId) {
@@ -52,5 +66,24 @@ export class SEPResolvers {
     }
 
     return context.queries.user.getBasic(context.user, sep.sepSecretaryUserId);
+  }
+
+  @FieldResolver(() => Int, { nullable: true })
+  async sepSecretaryProposalCount(
+    @Root() sep: SEP,
+    @Ctx() context: ResolverContext
+  ) {
+    if (!sep.sepSecretaryUserId) {
+      return null;
+    }
+
+    return context.queries.sep.dataSource.getSEPReviewerProposalCount(
+      sep.sepSecretaryUserId
+    );
+  }
+
+  @FieldResolver(() => Int)
+  async proposalCount(@Root() sep: SEP, @Ctx() context: ResolverContext) {
+    return context.queries.sep.dataSource.getSEPProposalCount(sep.id);
   }
 }

--- a/src/resolvers/types/SEPReviwers.ts
+++ b/src/resolvers/types/SEPReviwers.ts
@@ -36,4 +36,14 @@ export class SEPUserResolver {
   async user(@Root() sepMember: SEPReviewer, @Ctx() context: ResolverContext) {
     return context.queries.user.dataSource.getBasicUserInfo(sepMember.userId);
   }
+
+  @FieldResolver(() => Int)
+  async proposalsCount(
+    @Root() sepMember: SEPReviewer,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.queries.sep.dataSource.getSEPReviewerProposalCount(
+      sepMember.userId
+    );
+  }
 }


### PR DESCRIPTION
## Description

All SEPs have number of proposals in the table view and SEP members now have number of proposals they need to review. 

## Motivation and Context

It was hard to know about number of proposals which SEP member is responsible to review

## How Has This Been Tested

- e2e tests
- unit tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2597

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

Frontend PR: https://github.com/UserOfficeProject/user-office-frontend/pull/935

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
