### PR TITLE
Remove duplicate proposals in instrument scientist view

### DIFF
--- a/db_patches/0122_RevertAddCallInstrumentsToProposalView.sql
+++ b/db_patches/0122_RevertAddCallInstrumentsToProposalView.sql
@@ -1,0 +1,55 @@
+DO
+$$
+BEGIN
+  IF register_patch('RevertAddCallInstrumentsToProposalView.sql', 'Cosimo Campo', 'Revert all changes from AddCallInstrumentsToProposalView', '2022-06-01') THEN
+    -- drop view to allow recreating it
+    DROP VIEW proposal_table_view;
+
+    -- re-create view as it was before AddCallInstrumentsToProposalView
+    CREATE VIEW proposal_table_view
+    AS
+    SELECT  p.proposal_pk AS proposal_pk,
+            p.title,
+            p.status_id AS proposal_status_id,
+            ps.name AS proposal_status_name,
+            ps.description AS proposal_status_description,
+            p.proposal_id,
+            smd.rank_order as rank_order,
+            p.final_status,
+            p.notified,
+            p.questionary_id,
+            t.time_allocation as technical_time_allocation,
+            p.management_time_allocation,
+            t.technical_review_assignee_id,
+            u.firstname as technical_review_assignee_firstname,
+            u.lastname as technical_review_assignee_lastname,
+            t.status AS technical_review_status,
+            t.submitted as technical_review_submitted,
+            i.name AS instrument_name,
+            c.call_short_code,
+            s.code AS sep_code,
+            s.sep_id AS sep_id,
+            c.allocation_time_unit,
+            c.call_id,
+            i.instrument_id,
+            ( SELECT round(avg("SEP_Reviews".grade), 1) AS round
+                    FROM "SEP_Reviews"
+                    WHERE "SEP_Reviews".proposal_pk = p.proposal_pk) AS average,
+            ( SELECT round(stddev_pop("SEP_Reviews".grade), 1) AS round
+                    FROM "SEP_Reviews"
+                    WHERE "SEP_Reviews".proposal_pk = p.proposal_pk) AS deviation,
+            p.submitted
+    FROM proposals p
+    LEFT JOIN technical_review t ON t.proposal_pk = p.proposal_pk
+    LEFT JOIN users u ON u.user_id = t.technical_review_assignee_id
+    LEFT JOIN instrument_has_proposals ihp ON ihp.proposal_pk = p.proposal_pk
+    LEFT JOIN proposal_statuses ps ON ps.proposal_status_id = p.status_id
+    LEFT JOIN instruments i ON i.instrument_id = ihp.instrument_id
+    LEFT JOIN call c ON c.call_id = p.call_id
+    LEFT JOIN "SEP_Proposals" sp ON sp.proposal_pk = p.proposal_pk
+    LEFT JOIN "SEPs" s ON s.sep_id = sp.sep_id
+    LEFT JOIN "SEP_meeting_decisions" smd ON smd.proposal_pk = p.proposal_pk;
+  END IF;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -351,7 +351,7 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
         }
         if (filter?.instrumentId) {
           query.where(
-            'proposal_table_view.proposal_instrument_id',
+            'proposal_table_view.instrument_id',
             filter?.instrumentId
           );
         }
@@ -502,12 +502,11 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
       ])
       .from('proposal_table_view')
       .join('instruments', {
-        'instruments.instrument_id':
-          'proposal_table_view.proposal_instrument_id',
+        'instruments.instrument_id': 'proposal_table_view.instrument_id',
       })
       .leftJoin('instrument_has_scientists', {
         'instrument_has_scientists.instrument_id':
-          'proposal_table_view.proposal_instrument_id',
+          'proposal_table_view.instrument_id',
       })
       .where(function () {
         this.where('instrument_has_scientists.user_id', scientistId).orWhere(

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -111,15 +111,13 @@ export interface ProposalViewRecord {
   readonly technical_review_assignee_id: number;
   readonly technical_review_assignee_firstname: string;
   readonly technical_review_assignee_lastname: string;
+  readonly instrument_name: string;
   readonly call_short_code: string;
   readonly sep_id: number;
   readonly sep_code: string;
   readonly average: number;
   readonly deviation: number;
-  readonly proposal_instrument_name: string;
-  readonly proposal_instrument_id: number;
-  readonly call_instrument_name: string;
-  readonly call_instrument_id: number;
+  readonly instrument_id: number;
   readonly call_id: number;
   readonly submitted: boolean;
   readonly allocation_time_unit: AllocationTimeUnits;
@@ -689,17 +687,13 @@ export const createProposalViewObject = (proposal: ProposalViewRecord) => {
     proposal.technical_review_assignee_lastname,
     proposal.technical_review_status,
     proposal.technical_review_submitted,
-    proposal.proposal_instrument_name
-      ? proposal.proposal_instrument_name
-      : proposal.call_instrument_name,
+    proposal.instrument_name,
     proposal.call_short_code,
     proposal.sep_code,
     proposal.sep_id,
     proposal.average,
     proposal.deviation,
-    proposal.proposal_instrument_id
-      ? proposal.proposal_instrument_id
-      : proposal.call_instrument_id,
+    proposal.instrument_id,
     proposal.allocation_time_unit,
     proposal.call_id,
     proposal.submitted


### PR DESCRIPTION
## Description
Reverts the recent changes (https://github.com/UserOfficeProject/user-office-backend/pull/658) to the proposal table view which produced duplicate records when the proposal was assigned to a call with multiple instruments.

STFC still needs to show proposals for a call's instrument rather than proposals directly assigned to an instrument, so the logic for doing this has been moved to the STFC ProposalDataSource. This will likely slow down the STFC instrument scientist page, but avoid the complexity of making the DB view change work for both facilities.

Note that the STFC datasource relies on the assumption that we won't be using the proposal's assigned instrument there: it only looks at the call instrument. This will break if we ever start assigning proposals directly.

## Motivation and Context

## How Has This Been Tested
- Manual testing on my machine

## Fixes
Closes https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/609

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
