### PR TITLE
feat: Make SEPs and SEP Proposals visible to SEP_Reviewer

### DIFF
--- a/src/datasources/ProposalDataSource.ts
+++ b/src/datasources/ProposalDataSource.ts
@@ -72,6 +72,7 @@ export interface ProposalDataSource {
     callId: number,
     statusId: number
   ): Promise<boolean>;
+  getProposalEvents(proposalPk: number): Promise<ProposalEventsRecord | null>;
   changeProposalsStatus(
     statusId: number,
     proposalPks: number[]

--- a/src/datasources/mockups/ProposalDataSource.ts
+++ b/src/datasources/mockups/ProposalDataSource.ts
@@ -97,6 +97,34 @@ export const dummyProposalTechnicalReview = new TechnicalReview(
   1
 );
 
+const dummyProposalEvents = {
+  proposal_pk: 1,
+  proposal_created: true,
+  proposal_submitted: true,
+  proposal_feasible: true,
+  proposal_unfeasible: false,
+  call_ended: false,
+  call_review_ended: false,
+  proposal_sep_selected: false,
+  proposal_instrument_selected: false,
+  proposal_feasibility_review_submitted: false,
+  proposal_sample_review_submitted: false,
+  proposal_all_sep_reviews_submitted: false,
+  proposal_feasibility_review_updated: false,
+  proposal_management_decision_submitted: false,
+  proposal_management_decision_updated: false,
+  proposal_sample_safe: false,
+  proposal_sep_review_updated: false,
+  proposal_all_sep_reviewers_selected: false,
+  proposal_sep_review_submitted: false,
+  proposal_sep_meeting_submitted: false,
+  proposal_instrument_submitted: false,
+  proposal_accepted: false,
+  proposal_reserved: false,
+  proposal_rejected: false,
+  proposal_notified: false,
+};
+
 export class ProposalDataSourceMock implements ProposalDataSource {
   proposalsUpdated: Proposal[];
   constructor() {
@@ -287,33 +315,13 @@ export class ProposalDataSourceMock implements ProposalDataSource {
     event: Event,
     proposalPk: number
   ): Promise<ProposalEventsRecord | null> {
-    return {
-      proposal_pk: 1,
-      proposal_created: true,
-      proposal_submitted: true,
-      proposal_feasible: true,
-      proposal_unfeasible: false,
-      call_ended: false,
-      call_review_ended: false,
-      proposal_sep_selected: false,
-      proposal_instrument_selected: false,
-      proposal_feasibility_review_submitted: false,
-      proposal_sample_review_submitted: false,
-      proposal_all_sep_reviews_submitted: false,
-      proposal_feasibility_review_updated: false,
-      proposal_management_decision_submitted: false,
-      proposal_management_decision_updated: false,
-      proposal_sample_safe: false,
-      proposal_sep_review_updated: false,
-      proposal_all_sep_reviewers_selected: false,
-      proposal_sep_review_submitted: false,
-      proposal_sep_meeting_submitted: false,
-      proposal_instrument_submitted: false,
-      proposal_accepted: false,
-      proposal_reserved: false,
-      proposal_rejected: false,
-      proposal_notified: false,
-    };
+    return dummyProposalEvents;
+  }
+
+  async getProposalEvents(
+    proposalPk: number
+  ): Promise<ProposalEventsRecord | null> {
+    return dummyProposalEvents;
   }
 
   async getCount(callId: number): Promise<number> {

--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -649,6 +649,22 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
     }
   }
 
+  async getProposalEvents(
+    proposalPk: number
+  ): Promise<ProposalEventsRecord | null> {
+    const result = await database
+      .select()
+      .from('proposal_events')
+      .where('proposal_pk', proposalPk)
+      .first();
+
+    if (!result) {
+      return null;
+    }
+
+    return result;
+  }
+
   async getCount(callId: number): Promise<number> {
     return database('proposals')
       .count('call_id')

--- a/src/datasources/postgres/SEPDataSource.ts
+++ b/src/datasources/postgres/SEPDataSource.ts
@@ -147,14 +147,13 @@ export default class PostgresSEPDataSource implements SEPDataSource {
       qb.where('sep_chair_user_id', userId);
     } else if (role.shortCode === Roles.SEP_SECRETARY) {
       qb.where('sep_secretary_user_id', userId);
-      // Note: keep it in case we need it in the future
-      // } else if (role.shortCode === Roles.SEP_REVIEWER) {
-      //   qb.join(
-      //     'SEP_Reviewers',
-      //     'SEP_Reviewers.sep_id',
-      //     '=',
-      //     'SEPs.sep_id'
-      //   ).where('SEP_Reviewers.user_id', userId);
+    } else if (role.shortCode === Roles.SEP_REVIEWER) {
+      qb.join(
+        'SEP_Reviewers',
+        'SEP_Reviewers.sep_id',
+        '=',
+        'SEPs.sep_id'
+      ).where('SEP_Reviewers.user_id', userId);
     } else {
       logger.logWarn('User tried to list its SEPs but has invalid role', {
         userId,

--- a/src/queries/SEPQueries.ts
+++ b/src/queries/SEPQueries.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from 'tsyringe';
 
 import { UserAuthorization } from '../auth/UserAuthorization';
 import { Tokens } from '../config/Tokens';
+import { ProposalDataSource } from '../datasources/ProposalDataSource';
 import { SEPDataSource } from '../datasources/SEPDataSource';
 import { Authorized } from '../decorators';
 import { Roles } from '../models/Role';
@@ -11,10 +12,17 @@ import { UserWithRole } from '../models/User';
 export default class SEPQueries {
   constructor(
     @inject(Tokens.SEPDataSource) public dataSource: SEPDataSource,
+    @inject(Tokens.ProposalDataSource)
+    public proposalDataSource: ProposalDataSource,
     @inject(Tokens.UserAuthorization) private userAuth: UserAuthorization
   ) {}
 
-  @Authorized([Roles.USER_OFFICER, Roles.SEP_CHAIR, Roles.SEP_SECRETARY])
+  @Authorized([
+    Roles.USER_OFFICER,
+    Roles.SEP_CHAIR,
+    Roles.SEP_SECRETARY,
+    Roles.SEP_REVIEWER,
+  ])
   async get(agent: UserWithRole | null, id: number) {
     const sep = await this.dataSource.getSEP(id);
 
@@ -53,7 +61,12 @@ export default class SEPQueries {
     return this.dataSource.getReviewers(sepId);
   }
 
-  @Authorized([Roles.USER_OFFICER, Roles.SEP_CHAIR, Roles.SEP_SECRETARY])
+  @Authorized([
+    Roles.USER_OFFICER,
+    Roles.SEP_CHAIR,
+    Roles.SEP_SECRETARY,
+    Roles.SEP_REVIEWER,
+  ])
   async getSEPProposals(
     agent: UserWithRole | null,
     { sepId, callId }: { sepId: number; callId: number | null }
@@ -68,7 +81,12 @@ export default class SEPQueries {
     }
   }
 
-  @Authorized([Roles.USER_OFFICER, Roles.SEP_CHAIR, Roles.SEP_SECRETARY])
+  @Authorized([
+    Roles.USER_OFFICER,
+    Roles.SEP_CHAIR,
+    Roles.SEP_SECRETARY,
+    Roles.SEP_REVIEWER,
+  ])
   async getSEPProposal(
     agent: UserWithRole | null,
     { sepId, proposalPk }: { sepId: number; proposalPk: number }
@@ -111,7 +129,12 @@ export default class SEPQueries {
     }
   }
 
-  @Authorized([Roles.USER_OFFICER, Roles.SEP_CHAIR, Roles.SEP_SECRETARY])
+  @Authorized([
+    Roles.USER_OFFICER,
+    Roles.SEP_CHAIR,
+    Roles.SEP_SECRETARY,
+    Roles.SEP_REVIEWER,
+  ])
   async getSEPProposalAssignments(
     agent: UserWithRole | null,
     {
@@ -124,10 +147,15 @@ export default class SEPQueries {
   ) {
     let reviewerId = null;
 
+    const proposalEvents = await this.proposalDataSource.getProposalEvents(
+      proposalPk
+    );
+
     if (
       agent &&
       !this.userAuth.isUserOfficer(agent) &&
-      !(await this.userAuth.isChairOrSecretaryOfSEP(agent, sepId))
+      !(await this.userAuth.isChairOrSecretaryOfSEP(agent, sepId)) &&
+      !proposalEvents?.proposal_all_sep_reviews_submitted
     ) {
       reviewerId = agent.id;
     }

--- a/src/queries/SEPQueries.ts
+++ b/src/queries/SEPQueries.ts
@@ -151,6 +151,7 @@ export default class SEPQueries {
       proposalPk
     );
 
+    // NOTE: If not officer, SEP Chair or SEP Secretary should return all proposal assignments only if everything is submitted. Otherwise for SEP Reviewer return only it's own proposal reviews.
     if (
       agent &&
       !this.userAuth.isUserOfficer(agent) &&


### PR DESCRIPTION
## Description

Now every SEP reviewer will be able to see SEPs that he is part of and view the proposals inside. After submitting the review and if all reviews are submitted then he/she can see all reviews on proposal.

## Motivation and Context

Previously SEP reviewer wasn't able to see SEPs and only able to see his own proposals that he needs to grade.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2598

## Changes

https://user-images.githubusercontent.com/6333063/172836699-21f28250-c291-4a37-a4a6-7de104889804.mp4

## Depends on

Backend PR: https://github.com/UserOfficeProject/user-office-backend/pull/669


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
