### PR TITLE
feat: Add organizationId to the basic user details to be able to use it on the frontend

### DIFF
--- a/src/datasources/mockups/UserDataSource.ts
+++ b/src/datasources/mockups/UserDataSource.ts
@@ -16,6 +16,7 @@ export const basicDummyUser = new BasicUserDetails(
   'doe',
   'john',
   'org',
+  1,
   'boss',
   new Date('2019-07-17 08:25:12.23043+00'),
   false
@@ -27,6 +28,7 @@ export const basicDummyUserNotOnProposal = new BasicUserDetails(
   'doe',
   'john',
   'org',
+  1,
   'boss',
   new Date('2019-07-17 08:25:12.23043+00'),
   false
@@ -222,6 +224,7 @@ export class UserDataSourceMock implements UserDataSource {
       'Smith',
       'John',
       'ESS',
+      2,
       'Manager',
       new Date('2019-07-17 08:25:12.23043+00'),
       false
@@ -254,6 +257,7 @@ export class UserDataSourceMock implements UserDataSource {
       'Smith',
       'John',
       'ESS',
+      2,
       'Manager',
       new Date('2019-07-17 08:25:12.23043+00'),
       false

--- a/src/datasources/postgres/records.ts
+++ b/src/datasources/postgres/records.ts
@@ -783,6 +783,7 @@ export const createBasicUserObject = (user: UserRecord) => {
     user.lastname,
     user.preferredname,
     user.institution,
+    user.organisation,
     user.position,
     user.created_at,
     user.placeholder

--- a/src/datasources/stfc/StfcUserDataSource.ts
+++ b/src/datasources/stfc/StfcUserDataSource.ts
@@ -44,6 +44,7 @@ export interface StfcBasicPersonDetails {
   givenName: string;
   initials: string;
   orgName: string;
+  orgId: number;
   title: string;
   userNumber: string;
   workPhone: string;
@@ -58,6 +59,7 @@ function toEssBasicUserDetails(
     stfcUser.familyName ?? '',
     stfcUser.displayName ?? '',
     stfcUser.orgName ?? '',
+    stfcUser.orgId ?? 1,
     '',
     new Date(),
     false

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -87,6 +87,7 @@ export class BasicUserDetails {
     public lastname: string,
     public preferredname: string,
     public organisation: string,
+    public organizationId: number,
     public position: string,
     public created: Date,
     public placeholder: boolean

--- a/src/queries/UserQueries.ts
+++ b/src/queries/UserQueries.ts
@@ -58,6 +58,7 @@ export default class UserQueries {
         user.lastname,
         user.preferredname,
         user.organisation,
+        user.organizationId,
         user.position,
         user.created,
         user.placeholder
@@ -84,6 +85,7 @@ export default class UserQueries {
       user.lastname,
       user.preferredname,
       user.organisation,
+      user.organizationId,
       user.position,
       user.created,
       user.placeholder

--- a/src/resolvers/types/BasicUserDetails.ts
+++ b/src/resolvers/types/BasicUserDetails.ts
@@ -21,6 +21,9 @@ export class BasicUserDetails implements Partial<BasicUserDetailsOrigin> {
   @Field()
   public organisation: string;
 
+  @Field(() => Int)
+  public organizationId: number;
+
   @Field()
   public position: string;
 

--- a/src/resolvers/types/Proposal.ts
+++ b/src/resolvers/types/Proposal.ts
@@ -83,6 +83,7 @@ export class Proposal implements Partial<ProposalOrigin> {
   @Field(() => Boolean)
   public managementDecisionSubmitted: boolean;
 
+  @Field(() => Int)
   public proposerId: number;
 }
 


### PR DESCRIPTION
## Description

This PR aims to add the organizationId to the BasicUserDetails so we would be able to use that when we compare on the frontend.

## Motivation and Context

Previously only organization name was returned which is not relevant to compare by.

## How Has This Been Tested

- e2e tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2493

## Changes


https://user-images.githubusercontent.com/6333063/173020479-270a7b87-63af-475d-8739-40ffda147d40.mp4

## Depends on

Frontend PR: https://github.com/UserOfficeProject/user-office-frontend/pull/945

## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
