### PR TITLE
fix: Prevent random STFC logouts by reducing UOWS requests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ package-lock.json
 node_modules/
 .github/workflows/
 README.md
+/src/datasources/stfc/UOWSSoapInterface.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "@types/yup": "^0.29.13",
         "@typescript-eslint/eslint-plugin": "^5.7.0",
         "@typescript-eslint/parser": "^5.7.0",
-        "@user-office-software/uows_client_generator": "^2.3.0",
+        "@user-office-software/uows_client_generator": "^3.0.0",
         "commander": "^5.1.0",
         "eslint": "^8.4.1",
         "eslint-config-prettier": "^8.3.0",
@@ -2088,19 +2088,19 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
+      "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/type-utils": "5.10.1",
-        "@typescript-eslint/utils": "5.10.1",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/type-utils": "5.27.1",
+        "@typescript-eslint/utils": "5.27.1",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2118,6 +2118,119 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+      "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
@@ -2140,15 +2253,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2164,6 +2277,95 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -2184,13 +2386,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
+      "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.10.1",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.27.1",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2207,6 +2409,119 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+      "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.27.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -2338,19 +2653,23 @@
       }
     },
     "node_modules/@user-office-software/uows_client_generator": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/uows_client_generator/-/uows_client_generator-2.3.0.tgz",
-      "integrity": "sha512-fPccLYw8asrbmZyBjO7NKLMBDXDeyq1ngyRhAYs+Pz3mHa4wnaf5Ol1PCHkI6fH68AgRUGXRstNnVlk8oAAPMg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/uows_client_generator/-/uows_client_generator-3.0.0.tgz",
+      "integrity": "sha512-JSj5wTsxFOG5xEZnZH4wEXpa9C5n+IWA3BXrNyUZYakCExjEs1S+BjHekjXx211JsP4AovHmbxH1juaGTX/bhA==",
       "dev": true,
       "dependencies": {
         "@user-office-software/duo-logger": "^1.1.3",
-        "soap": "^0.40.0",
+        "soap": "^0.43.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.4.4",
+        "typescript": "^4.6.4",
         "yargs": "^16.2.0"
       },
       "bin": {
         "uows-client-generator": "lib/index/index.js"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.5.0"
       }
     },
     "node_modules/@user-office-software/uows_client_generator/node_modules/@user-office-software/duo-logger": {
@@ -2361,6 +2680,46 @@
       "dependencies": {
         "fast-safe-stringify": "^2.1.1",
         "gelf-pro": "^1.3.6"
+      }
+    },
+    "node_modules/@user-office-software/uows_client_generator/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/@user-office-software/uows_client_generator/node_modules/soap": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/soap/-/soap-0.43.0.tgz",
+      "integrity": "sha512-Dgp6TD9f3NXvKhBy95XXphiSlNIU2RSc9PP1NEgBOE1laUWP+bdF+8uT1lf1tFadFEAYurFg6/s2tNil6rlltw==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.21.1",
+        "axios-ntlm": "^1.2.0",
+        "content-type-parser": "^1.0.2",
+        "debug": "^4.3.2",
+        "formidable": "^1.2.2",
+        "get-stream": "^6.0.1",
+        "lodash": "^4.17.21",
+        "sax": ">=0.6",
+        "strip-bom": "^3.0.0",
+        "uuid": "^8.3.2",
+        "xml-crypto": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@user-office-software/uows_client_generator/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3717,6 +4076,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
+    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -3925,9 +4290,9 @@
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4720,9 +5085,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5246,6 +5611,16 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "dev": true,
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -11087,9 +11462,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13404,20 +13779,86 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
+      "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/type-utils": "5.10.1",
-        "@typescript-eslint/utils": "5.10.1",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/type-utils": "5.27.1",
+        "@typescript-eslint/utils": "5.27.1",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+          "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+          "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+          "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+          "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.27.1",
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/typescript-estree": "5.27.1",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+          "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -13430,15 +13871,67 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+          "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+          "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+          "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+          "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {
@@ -13452,14 +13945,80 @@
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
+      "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.10.1",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.27.1",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+          "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+          "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+          "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/visitor-keys": "5.27.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+          "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.27.1",
+            "@typescript-eslint/types": "5.27.1",
+            "@typescript-eslint/typescript-estree": "5.27.1",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.27.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+          "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.27.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/types": {
@@ -13553,15 +14112,15 @@
       }
     },
     "@user-office-software/uows_client_generator": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/uows_client_generator/-/uows_client_generator-2.3.0.tgz",
-      "integrity": "sha512-fPccLYw8asrbmZyBjO7NKLMBDXDeyq1ngyRhAYs+Pz3mHa4wnaf5Ol1PCHkI6fH68AgRUGXRstNnVlk8oAAPMg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/uows_client_generator/-/uows_client_generator-3.0.0.tgz",
+      "integrity": "sha512-JSj5wTsxFOG5xEZnZH4wEXpa9C5n+IWA3BXrNyUZYakCExjEs1S+BjHekjXx211JsP4AovHmbxH1juaGTX/bhA==",
       "dev": true,
       "requires": {
         "@user-office-software/duo-logger": "^1.1.3",
-        "soap": "^0.40.0",
+        "soap": "^0.43.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.4.4",
+        "typescript": "^4.6.4",
         "yargs": "^16.2.0"
       },
       "dependencies": {
@@ -13574,6 +14133,40 @@
             "fast-safe-stringify": "^2.1.1",
             "gelf-pro": "^1.3.6"
           }
+        },
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "soap": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/soap/-/soap-0.43.0.tgz",
+          "integrity": "sha512-Dgp6TD9f3NXvKhBy95XXphiSlNIU2RSc9PP1NEgBOE1laUWP+bdF+8uT1lf1tFadFEAYurFg6/s2tNil6rlltw==",
+          "dev": true,
+          "requires": {
+            "axios": "^0.21.1",
+            "axios-ntlm": "^1.2.0",
+            "content-type-parser": "^1.0.2",
+            "debug": "^4.3.2",
+            "formidable": "^1.2.2",
+            "get-stream": "^6.0.1",
+            "lodash": "^4.17.21",
+            "sax": ">=0.6",
+            "strip-bom": "^3.0.0",
+            "uuid": "^8.3.2",
+            "xml-crypto": "^2.1.3"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },
@@ -14631,6 +15224,12 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
+    "content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -14805,9 +15404,9 @@
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -15413,9 +16012,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
     "esm": {
@@ -15811,6 +16410,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.2.0",
@@ -20219,9 +20824,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true
     },
     "uc.micro": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,8 +75,8 @@
         "@types/sparkpost": "^2.1.5",
         "@types/validator": "^13.7.0",
         "@types/yup": "^0.29.13",
-        "@typescript-eslint/eslint-plugin": "^5.7.0",
-        "@typescript-eslint/parser": "^5.7.0",
+        "@typescript-eslint/eslint-plugin": "^5.27.1",
+        "@typescript-eslint/parser": "^5.27.1",
         "@user-office-software/uows_client_generator": "^3.0.0",
         "commander": "^5.1.0",
         "eslint": "^8.4.1",
@@ -94,7 +94,7 @@
         "sinon": "^9.2.4",
         "ts-jest": "^27.1.2",
         "ts-node-dev": "^1.1.8",
-        "typescript": "^4.5.4"
+        "typescript": "^4.7.3"
       },
       "engines": {
         "node": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/yup": "^0.29.13",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
-    "@user-office-software/uows_client_generator": "^2.3.0",
+    "@user-office-software/uows_client_generator": "^3.0.0",
     "commander": "^5.1.0",
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "@types/sparkpost": "^2.1.5",
     "@types/validator": "^13.7.0",
     "@types/yup": "^0.29.13",
-    "@typescript-eslint/eslint-plugin": "^5.7.0",
-    "@typescript-eslint/parser": "^5.7.0",
+    "@typescript-eslint/eslint-plugin": "^5.27.1",
+    "@typescript-eslint/parser": "^5.27.1",
     "@user-office-software/uows_client_generator": "^3.0.0",
     "commander": "^5.1.0",
     "eslint": "^8.4.1",
@@ -124,7 +124,7 @@
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.2",
     "ts-node-dev": "^1.1.8",
-    "typescript": "^4.5.4"
+    "typescript": "^4.7.3"
   },
   "engines": {
     "npm": ">=8.0.0",

--- a/src/auth/StfcUserAuthorization.ts
+++ b/src/auth/StfcUserAuthorization.ts
@@ -16,7 +16,7 @@ import { Instrument } from '../models/Instrument';
 import { User } from '../models/User';
 import { UserAuthorization } from './UserAuthorization';
 
-const client = new UOWSSoapClient(process.env.EXTERNAL_AUTH_SERVICE_URL);
+const client = UOWSSoapClient.getInstance();
 
 const stfcInstrumentScientistRolesToInstrument: Record<string, string[]> = {
   'User Officer': ['ISIS', 'ARTEMIS', 'HPL', 'LSF'],

--- a/src/auth/UserAuthorization.ts
+++ b/src/auth/UserAuthorization.ts
@@ -109,7 +109,7 @@ export abstract class UserAuthorization {
 
     const isUserOfficer = this.isUserOfficer(agent);
     const isInstrumentScientist = this.isInstrumentScientist(agent);
-    const isSEPMember = this.isMemberOfSEP(agent, agent.id);
+    const isSEPMember = await this.isMemberOfSEP(agent, agent.id);
     if (isUserOfficer || isInstrumentScientist || isSEPMember) {
       return ids;
     }

--- a/src/datasources/stfc/StfcUserDataSource.ts
+++ b/src/datasources/stfc/StfcUserDataSource.ts
@@ -9,7 +9,7 @@ import { UserDataSource } from '../UserDataSource';
 import UOWSSoapClient from './UOWSSoapInterface';
 
 const postgresUserDataSource = new PostgresUserDataSource();
-const client = new UOWSSoapClient(process.env.EXTERNAL_AUTH_SERVICE_URL);
+const client = UOWSSoapClient.getInstance();
 const token = process.env.EXTERNAL_AUTH_TOKEN;
 
 type StfcRolesToEssRole = { [key: string]: Roles[] };

--- a/src/datasources/stfc/UOWSSoapInterface.ts
+++ b/src/datasources/stfc/UOWSSoapInterface.ts
@@ -1,5290 +1,2584 @@
-import * as soap from 'soap';
-import { logger } from '@user-office-software/duo-logger';
 
-export default class UOWSSoapClient {
-  private wsdlUrl: string;
-  private wsdlDesc: any = {
-    UserOfficeWebService: {
-      UserOfficeWebServicePort: {
-        getBasicPeopleDetailsFromSurname: {
-          input: {
-            Token: 'xs:string',
-            Surname: 'xs:string',
-            FuzzySearch: 'xs:boolean',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getAgeRangeOptions: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPersonDetailsByEncryptedId: {
-          input: {
-            token: 'xs:string',
-            encryptedId: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getSearchableBasicPeopleDetailsFromSurname: {
-          input: {
-            Token: 'xs:string',
-            Surname: 'xs:string',
-            FuzzySearch: 'xs:boolean',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        unlinkAlternativeIdentifierToUser: {
-          input: {
-            Token: 'xs:string',
-            AlternativeIdentifier: {
-              created: 'xs:dateTime',
-              createdBy: 'xs:string',
-              displayName: 'xs:string',
-              modified: 'xs:dateTime',
-              modifiedBy: 'xs:string',
-              provider: 'xs:string',
-              secretKey: 'xs:string',
-              thruDate: 'xs:dateTime',
-              userNumber: 'xs:string',
-              uuid: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPrivacyDTO: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              searchable: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getEstablishmentDTO: {
-          input: {
-            establishmentId: 'xs:long',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              buildingName: 'xs:string',
-              buildingNumber: 'xs:string',
-              cityTown: 'xs:string',
-              country: 'xs:string',
-              countyProvinceState: 'xs:string',
-              deptAccronym: 'xs:string',
-              deptName: 'xs:string',
-              district: 'xs:string',
-              establishmentId: 'xs:long',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              poBox: 'xs:string',
-              postalCode: 'xs:string',
-              site: 'xs:string',
-              street: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPersonDetailsFromSessionId: {
-          input: {
-            SessionId: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              emergencyContact: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              mobilePhone: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              status: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getInductionsFacilityAwarenessForUser: {
-          input: {
-            arg0: 'xs:string',
-            arg1: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              'facilities[]': 'xs:string',
-              'inductions[]': {
-                course: 'xs:string',
-                dateTaken: 'xs:dateTime',
-                id: 'xs:long',
-                modifiedBy: 'xs:string',
-                modifiedByName: 'xs:string',
-                modifiedDate: 'xs:dateTime',
-                thruDate: 'xs:dateTime',
-                userNumber: 'xs:string',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPersonsFacilities: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getEstablishmentDTOsBySearchDetails: {
-          input: {
-            'searchDetails[]': {
-              departmentName: 'xs:string',
-              organisationName: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              buildingName: 'xs:string',
-              buildingNumber: 'xs:string',
-              cityTown: 'xs:string',
-              country: 'xs:string',
-              countyProvinceState: 'xs:string',
-              deptAccronym: 'xs:string',
-              deptName: 'xs:string',
-              district: 'xs:string',
-              establishmentId: 'xs:long',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              poBox: 'xs:string',
-              postalCode: 'xs:string',
-              site: 'xs:string',
-              street: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPeopleDetailsFromUserNumbers: {
-          input: {
-            Token: 'xs:string',
-            'UserNumbers[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              emergencyContact: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              mobilePhone: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              status: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getSearchableBasicPersonDetailsFromUserNumber: {
-          input: {
-            Token: 'xs:string',
-            UserNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        deleteEstablishmentById: {
-          input: {
-            Token: 'xs:string',
-            EstablishmentId: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getAllTitles: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        updatePersonByDTO: {
-          input: {
-            token: 'xs:string',
-            person: {
-              deactivated: 'xs:boolean',
-              displayName: 'xs:string',
-              dpaDate: 'xs:dateTime',
-              email: 'xs:string',
-              establishmentId: 'xs:long',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fromDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              fullName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              marketingEmail: 'xs:string',
-              mobilePhone: 'xs:string',
-              resetPasswordDate: 'xs:dateTime',
-              rid: 'xs:long',
-              status: 'xs:string',
-              subscribedToMarketingEmails: 'xs:boolean',
-              thruDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPeopleDetailsFromEmails: {
-          input: {
-            Token: 'xs:string',
-            'Emails[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        loginWithAlternativeIdentifier: {
-          input: {
-            SystemSessionId: 'xs:string',
-            Uuid: 'xs:string',
-            Provider: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPersonDTOByMarketingEmail: {
-          input: {
-            token: 'xs:string',
-            marketingEmail: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              deactivated: 'xs:boolean',
-              displayName: 'xs:string',
-              dpaDate: 'xs:dateTime',
-              email: 'xs:string',
-              establishmentId: 'xs:long',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fromDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              fullName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              marketingEmail: 'xs:string',
-              mobilePhone: 'xs:string',
-              resetPasswordDate: 'xs:dateTime',
-              rid: 'xs:long',
-              status: 'xs:string',
-              subscribedToMarketingEmails: 'xs:boolean',
-              thruDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getSearchableBasicPeopleDetailsFromUserNumbers: {
-          input: {
-            Token: 'xs:string',
-            'UserNumbers[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        isTokenValid: {
-          input: {
-            Token: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:boolean',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getSearchableBasicPeopleDetailsFromEmails: {
-          input: {
-            Token: 'xs:string',
-            'Emails[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        updatePersonsFacilities: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            'facilities[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getMonitorDTO: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              ageOption: 'xs:string',
-              disability: 'xs:string',
-              ethnicity: 'xs:string',
-              gender: 'xs:string',
-              optIn: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        resetPassword: {
-          input: {
-            encryptedResetId: 'xs:string',
-            password: 'xs:string',
-            ipAddress: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getDataUsages: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              name: 'xs:string',
-              value: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        updateEmergencyContactDTO: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            emergencyContactDTO: {
-              contact: 'xs:string',
-              userNumber: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        sendAccountActivationEmail: {
-          input: {
-            Token: 'xs:string',
-            Email: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getDisabilities: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getEstablishmentsBySearchDetails: {
-          input: {
-            'searchDetails[]': {
-              departmentName: 'xs:string',
-              organisationName: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              departmentAcronym: 'xs:string',
-              departmentName: 'xs:string',
-              departmentUrl: 'xs:string',
-              establishmentId: 'xs:long',
-              groupAcronym: 'xs:string',
-              groupName: 'xs:string',
-              organisationAcronym: 'xs:string',
-              organisationName: 'xs:string',
-              organisationType: 'xs:string',
-              organisationUrl: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getRolesForUser: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              name: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        resetPasswordWithOldPassword: {
-          input: {
-            sessionId: 'xs:string',
-            oldPassword: 'xs:string',
-            newPassword: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getUsersPermissionUserGroupDTOs: {
-          input: {
-            Token: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              comments: 'xs:string',
-              groupName: 'xs:string',
-              id: 'xs:long',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        deactivatePerson: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        logout: {
-          input: {
-            SessionId: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        setPrivacyDTO: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            privacyDTO: {
-              searchable: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getChangesSince: {
-          input: {
-            Token: 'xs:string',
-            Since: 'xs:dateTime',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              comments: 'xs:string',
-              deactivated: 'xs:boolean',
-              dpaDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              email: 'xs:string',
-              establishmentId: 'xs:long',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fromDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              isisSalt: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastpwdreset: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              marketingEmail: 'xs:string',
-              mobilePhone: 'xs:string',
-              monitorId: 'xs:long',
-              newUserNumber: 'xs:string',
-              privacyId: 'xs:long',
-              rid: 'xs:long',
-              sha2: 'xs:string',
-              status: 'xs:string',
-              subscribedToMarketingEmails: 'xs:boolean',
-              thruDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              title: 'xs:string',
-              updated: 'xs:string',
-              userNumber: 'xs:string',
-              verified: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getGenders: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        createPersonFromPersonDTO: {
-          input: {
-            token: 'xs:string',
-            person: {
-              deactivated: 'xs:boolean',
-              displayName: 'xs:string',
-              dpaDate: 'xs:dateTime',
-              email: 'xs:string',
-              establishmentId: 'xs:long',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fromDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              fullName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              marketingEmail: 'xs:string',
-              mobilePhone: 'xs:string',
-              resetPasswordDate: 'xs:dateTime',
-              rid: 'xs:long',
-              status: 'xs:string',
-              subscribedToMarketingEmails: 'xs:boolean',
-              thruDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        loginWithAlternativeIdentifierECP: {
-          input: {
-            Provider: 'xs:string',
-            Username: 'xs:string',
-            Password: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        updateExpiredPassword: {
-          input: {
-            token: 'xs:string',
-            encryptedId: 'xs:string',
-            oldPassword: 'xs:string',
-            newPassword: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getDataLookup: {
-          input: {
-            Name: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        updateAlternativeIdentifiersForUser: {
-          input: {
-            Token: 'xs:string',
-            'AlternativeIdentifiers[]': {
-              created: 'xs:dateTime',
-              createdBy: 'xs:string',
-              displayName: 'xs:string',
-              modified: 'xs:dateTime',
-              modifiedBy: 'xs:string',
-              provider: 'xs:string',
-              secretKey: 'xs:string',
-              thruDate: 'xs:dateTime',
-              userNumber: 'xs:string',
-              uuid: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        noLdapLogin: {
-          input: {
-            UserNumber: 'xs:string',
-            Password: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getFrequentGenders: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getEthnicities: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPeopleDetailsSinceDate: {
-          input: {
-            Token: 'xs:string',
-            Date: 'xs:dateTime',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        createEstablishmentFromEstablishmentDTO: {
-          input: {
-            token: 'xs:string',
-            establishment: {
-              buildingName: 'xs:string',
-              buildingNumber: 'xs:string',
-              cityTown: 'xs:string',
-              country: 'xs:string',
-              countyProvinceState: 'xs:string',
-              deptAccronym: 'xs:string',
-              deptName: 'xs:string',
-              district: 'xs:string',
-              establishmentId: 'xs:long',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              poBox: 'xs:string',
-              postalCode: 'xs:string',
-              site: 'xs:string',
-              street: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:long',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPersonDetailsByEncryptedActivationId: {
-          input: {
-            token: 'xs:string',
-            encryptedActivationId: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        requestLinkExistingFedId: {
-          input: {
-            token: 'xs:string',
-            dob: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPersonDetailsFromEmail: {
-          input: {
-            Token: 'xs:string',
-            Email: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        requestNewFedId: {
-          input: {
-            token: 'xs:string',
-            dob: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        sendPasswordResetEmail: {
-          input: {
-            Token: 'xs:string',
-            Email: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getAllEstablishmentDTOs: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              buildingName: 'xs:string',
-              buildingNumber: 'xs:string',
-              cityTown: 'xs:string',
-              country: 'xs:string',
-              countyProvinceState: 'xs:string',
-              deptAccronym: 'xs:string',
-              deptName: 'xs:string',
-              district: 'xs:string',
-              establishmentId: 'xs:long',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              poBox: 'xs:string',
-              postalCode: 'xs:string',
-              site: 'xs:string',
-              street: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getEstablishmentDTOsByQuery: {
-          input: {
-            searchQuery: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              buildingName: 'xs:string',
-              buildingNumber: 'xs:string',
-              cityTown: 'xs:string',
-              country: 'xs:string',
-              countyProvinceState: 'xs:string',
-              deptAccronym: 'xs:string',
-              deptName: 'xs:string',
-              district: 'xs:string',
-              establishmentId: 'xs:long',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              poBox: 'xs:string',
-              postalCode: 'xs:string',
-              site: 'xs:string',
-              street: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        acceptLatestDataProtectionAgreement: {
-          input: {
-            token: 'xs:string',
-            encryptedId: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        setMonitorDTO: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            monitorDTO: {
-              ageOption: 'xs:string',
-              disability: 'xs:string',
-              ethnicity: 'xs:string',
-              gender: 'xs:string',
-              optIn: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        activateAccountWithoutPassword: {
-          input: {
-            encryptedActivationId: 'xs:string',
-            ipAddress: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPersonDetailsFromFedId: {
-          input: {
-            Token: 'xs:string',
-            FedId: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        activateAccount: {
-          input: {
-            encryptedActivationId: 'xs:string',
-            password: 'xs:string',
-            ipAddress: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPeopleDetailsFromUserNumbers: {
-          input: {
-            Token: 'xs:string',
-            'UserNumbers[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getAllCountries: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getSearchableBasicPersonDetailsFromEmail: {
-          input: {
-            Token: 'xs:string',
-            Email: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPersonDetailsFromUserNumber: {
-          input: {
-            Token: 'xs:string',
-            UserNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              emergencyContact: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              mobilePhone: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              status: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPersonDetailsFromEmail: {
-          input: {
-            Token: 'xs:string',
-            Email: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              emergencyContact: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              mobilePhone: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              status: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        createFedId: {
-          input: {
-            token: 'xs:string',
-            fedIdUserName: 'xs:string',
-            fedIdLoginPassword: 'xs:string',
-            person: {
-              comments: 'xs:string',
-              deactivated: 'xs:boolean',
-              dpaDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              email: 'xs:string',
-              establishmentId: 'xs:long',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fromDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              isisSalt: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastpwdreset: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              marketingEmail: 'xs:string',
-              mobilePhone: 'xs:string',
-              monitorId: 'xs:long',
-              newUserNumber: 'xs:string',
-              privacyId: 'xs:long',
-              rid: 'xs:long',
-              sha2: 'xs:string',
-              status: 'xs:string',
-              subscribedToMarketingEmails: 'xs:boolean',
-              thruDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              title: 'xs:string',
-              updated: 'xs:string',
-              userNumber: 'xs:string',
-              verified: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            status: 'xs:string',
-            expiryDate: 'xs:dateTime',
-            fedIdDob: 'xs:dateTime',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getAllFacilityNames: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPeopleDetailsFromEmails: {
-          input: {
-            Token: 'xs:string',
-            'Emails[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              emergencyContact: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              mobilePhone: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              status: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        isAlternativeIdentifierActive: {
-          input: {
-            Uuid: 'xs:string',
-            Provider: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:boolean',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        isAlternativeIdentifierLinked: {
-          input: {
-            Uuid: 'xs:string',
-            Provider: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:boolean',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        login: {
-          input: {
-            Account: 'xs:string',
-            Password: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        linkAlternativeIdentifierToUser: {
-          input: {
-            Token: 'xs:string',
-            AlternativeIdentifier: {
-              created: 'xs:dateTime',
-              createdBy: 'xs:string',
-              displayName: 'xs:string',
-              modified: 'xs:dateTime',
-              modifiedBy: 'xs:string',
-              provider: 'xs:string',
-              secretKey: 'xs:string',
-              thruDate: 'xs:dateTime',
-              userNumber: 'xs:string',
-              uuid: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getAlternativeIdentifiersForUser: {
-          input: {
-            Token: 'xs:string',
-            UserNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              created: 'xs:dateTime',
-              createdBy: 'xs:string',
-              displayName: 'xs:string',
-              modified: 'xs:dateTime',
-              modifiedBy: 'xs:string',
-              provider: 'xs:string',
-              secretKey: 'xs:string',
-              thruDate: 'xs:dateTime',
-              userNumber: 'xs:string',
-              uuid: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPeopleDetailsFromEstablishments: {
-          input: {
-            Token: 'xs:string',
-            'SearchDetails[]': {
-              departmentName: 'xs:string',
-              organisationName: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPersonDTOFromUserNumber: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              deactivated: 'xs:boolean',
-              displayName: 'xs:string',
-              dpaDate: 'xs:dateTime',
-              email: 'xs:string',
-              establishmentId: 'xs:long',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fromDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              fullName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              marketingEmail: 'xs:string',
-              mobilePhone: 'xs:string',
-              resetPasswordDate: 'xs:dateTime',
-              rid: 'xs:long',
-              status: 'xs:string',
-              subscribedToMarketingEmails: 'xs:boolean',
-              thruDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPersonDetailsByEncryptedPasswordResetId: {
-          input: {
-            token: 'xs:string',
-            encryptedResetId: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getAllEuCountries: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        isAccountActive: {
-          input: {
-            UserNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:boolean',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getAllPersonStatuses: {
-          input: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getBasicPersonDetailsFromUserNumber: {
-          input: {
-            Token: 'xs:string',
-            UserNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getPeopleDetailsFromSurname: {
-          input: {
-            Token: 'xs:string',
-            Surname: 'xs:string',
-            FuzzySearch: 'xs:boolean',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            'return[]': {
-              country: 'xs:string',
-              deptAcronym: 'xs:string',
-              deptName: 'xs:string',
-              displayName: 'xs:string',
-              email: 'xs:string',
-              emergencyContact: 'xs:string',
-              establishmentId: 'xs:string',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fullName: 'xs:string',
-              givenName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              mobilePhone: 'xs:string',
-              orgAcronym: 'xs:string',
-              orgName: 'xs:string',
-              status: 'xs:string',
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        getEmergencyContactDTO: {
-          input: {
-            token: 'xs:string',
-            userNumber: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: {
-              contact: 'xs:string',
-              userNumber: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        updateFedId: {
-          input: {
-            token: 'xs:string',
-            fedIdUserName: 'xs:string',
-            fedIdLoginPassword: 'xs:string',
-            objid: 'xs:string',
-            objdomid: 'xs:string',
-            expiryDate: 'xs:dateTime',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            return: 'xs:string',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-        updatePersonByDTOFromSource: {
-          input: {
-            token: 'xs:string',
-            person: {
-              deactivated: 'xs:boolean',
-              displayName: 'xs:string',
-              dpaDate: 'xs:dateTime',
-              email: 'xs:string',
-              establishmentId: 'xs:long',
-              familyName: 'xs:string',
-              fedId: 'xs:string',
-              firstName: 'xs:string',
-              firstNameKnownAs: 'xs:string',
-              fromDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              fullName: 'xs:string',
-              initials: 'xs:string',
-              joinedDate: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              lastAccessTime: {
-                nanos: 'xs:int',
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              marketingEmail: 'xs:string',
-              mobilePhone: 'xs:string',
-              resetPasswordDate: 'xs:dateTime',
-              rid: 'xs:long',
-              status: 'xs:string',
-              subscribedToMarketingEmails: 'xs:boolean',
-              thruDate: {
-                targetNSAlias: 'tns',
-                targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-              },
-              title: 'xs:string',
-              userNumber: 'xs:string',
-              workPhone: 'xs:string',
-              targetNSAlias: 'tns',
-              targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-            },
-            updateSource: 'requestSourceDTO|xs:string|DEFAULT,MAILING_API',
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-          output: {
-            targetNSAlias: 'tns',
-            targetNamespace: 'http://webservice.UserOffice.stfc.com/',
-          },
-        },
-      },
-    },
-  };
-
-  public constructor(wsdlUrl?: string) {
-    if (wsdlUrl == null)
-      this.wsdlUrl =
-        'https://devapis.facilities.rl.ac.uk/ws/UserOfficeWebService?wsdl';
-    else this.wsdlUrl = wsdlUrl;
-  }
-
-  public async getBasicPeopleDetailsFromSurname(
-    Token: any,
-    Surname: any,
-    FuzzySearch: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPeopleDetailsFromSurname',
-          Token,
-          Surname,
-          FuzzySearch
-        );
-        return client['getBasicPeopleDetailsFromSurnameAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPeopleDetailsFromSurname',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getAgeRangeOptions(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getAgeRangeOptions');
-        return client['getAgeRangeOptionsAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getAgeRangeOptions',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPersonDetailsByEncryptedId(
-    token: any,
-    encryptedId: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPersonDetailsByEncryptedId',
-          token,
-          encryptedId
-        );
-        return client['getBasicPersonDetailsByEncryptedIdAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPersonDetailsByEncryptedId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getSearchableBasicPeopleDetailsFromSurname(
-    Token: any,
-    Surname: any,
-    FuzzySearch: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getSearchableBasicPeopleDetailsFromSurname',
-          Token,
-          Surname,
-          FuzzySearch
-        );
-        return client['getSearchableBasicPeopleDetailsFromSurnameAsync'](
-          argsObj
-        );
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getSearchableBasicPeopleDetailsFromSurname',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async unlinkAlternativeIdentifierToUser(
-    Token: any,
-    AlternativeIdentifier: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'unlinkAlternativeIdentifierToUser',
-          Token,
-          AlternativeIdentifier
-        );
-        return client['unlinkAlternativeIdentifierToUserAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'unlinkAlternativeIdentifierToUser',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPrivacyDTO(token: any, userNumber: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getPrivacyDTO', token, userNumber);
-        return client['getPrivacyDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPrivacyDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getEstablishmentDTO(establishmentId: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getEstablishmentDTO',
-          establishmentId
-        );
-        return client['getEstablishmentDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getEstablishmentDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPersonDetailsFromSessionId(SessionId: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPersonDetailsFromSessionId',
-          SessionId
-        );
-        return client['getPersonDetailsFromSessionIdAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPersonDetailsFromSessionId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getInductionsFacilityAwarenessForUser(
-    arg0: any,
-    arg1: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getInductionsFacilityAwarenessForUser',
-          arg0,
-          arg1
-        );
-        return client['getInductionsFacilityAwarenessForUserAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getInductionsFacilityAwarenessForUser',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPersonsFacilities(token: any, userNumber: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPersonsFacilities',
-          token,
-          userNumber
-        );
-        return client['getPersonsFacilitiesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPersonsFacilities',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getEstablishmentDTOsBySearchDetails(
-    searchDetails: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getEstablishmentDTOsBySearchDetails',
-          searchDetails
-        );
-        return client['getEstablishmentDTOsBySearchDetailsAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getEstablishmentDTOsBySearchDetails',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPeopleDetailsFromUserNumbers(
-    Token: any,
-    UserNumbers: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPeopleDetailsFromUserNumbers',
-          Token,
-          UserNumbers
-        );
-        return client['getPeopleDetailsFromUserNumbersAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPeopleDetailsFromUserNumbers',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getSearchableBasicPersonDetailsFromUserNumber(
-    Token: any,
-    UserNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getSearchableBasicPersonDetailsFromUserNumber',
-          Token,
-          UserNumber
-        );
-        return client['getSearchableBasicPersonDetailsFromUserNumberAsync'](
-          argsObj
-        );
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getSearchableBasicPersonDetailsFromUserNumber',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async deleteEstablishmentById(
-    Token: any,
-    EstablishmentId: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'deleteEstablishmentById',
-          Token,
-          EstablishmentId
-        );
-        return client['deleteEstablishmentByIdAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'deleteEstablishmentById',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getAllTitles(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getAllTitles');
-        return client['getAllTitlesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getAllTitles',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async updatePersonByDTO(token: any, person: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('updatePersonByDTO', token, person);
-        return client['updatePersonByDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'updatePersonByDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPeopleDetailsFromEmails(
-    Token: any,
-    Emails: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPeopleDetailsFromEmails',
-          Token,
-          Emails
-        );
-        return client['getBasicPeopleDetailsFromEmailsAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPeopleDetailsFromEmails',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async loginWithAlternativeIdentifier(
-    SystemSessionId: any,
-    Uuid: any,
-    Provider: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'loginWithAlternativeIdentifier',
-          SystemSessionId,
-          Uuid,
-          Provider
-        );
-        return client['loginWithAlternativeIdentifierAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'loginWithAlternativeIdentifier',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPersonDTOByMarketingEmail(
-    token: any,
-    marketingEmail: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPersonDTOByMarketingEmail',
-          token,
-          marketingEmail
-        );
-        return client['getPersonDTOByMarketingEmailAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPersonDTOByMarketingEmail',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getSearchableBasicPeopleDetailsFromUserNumbers(
-    Token: any,
-    UserNumbers: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getSearchableBasicPeopleDetailsFromUserNumbers',
-          Token,
-          UserNumbers
-        );
-        return client['getSearchableBasicPeopleDetailsFromUserNumbersAsync'](
-          argsObj
-        );
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getSearchableBasicPeopleDetailsFromUserNumbers',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async isTokenValid(Token: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('isTokenValid', Token);
-        return client['isTokenValidAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'isTokenValid',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getSearchableBasicPeopleDetailsFromEmails(
-    Token: any,
-    Emails: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getSearchableBasicPeopleDetailsFromEmails',
-          Token,
-          Emails
-        );
-        return client['getSearchableBasicPeopleDetailsFromEmailsAsync'](
-          argsObj
-        );
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getSearchableBasicPeopleDetailsFromEmails',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async updatePersonsFacilities(
-    token: any,
-    userNumber: any,
-    facilities: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'updatePersonsFacilities',
-          token,
-          userNumber,
-          facilities
-        );
-        return client['updatePersonsFacilitiesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'updatePersonsFacilities',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getMonitorDTO(token: any, userNumber: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getMonitorDTO', token, userNumber);
-        return client['getMonitorDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getMonitorDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async resetPassword(
-    encryptedResetId: any,
-    password: any,
-    ipAddress: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'resetPassword',
-          encryptedResetId,
-          password,
-          ipAddress
-        );
-        return client['resetPasswordAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'resetPassword',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getDataUsages(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getDataUsages');
-        return client['getDataUsagesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getDataUsages',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async updateEmergencyContactDTO(
-    token: any,
-    userNumber: any,
-    emergencyContactDTO: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'updateEmergencyContactDTO',
-          token,
-          userNumber,
-          emergencyContactDTO
-        );
-        return client['updateEmergencyContactDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'updateEmergencyContactDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async sendAccountActivationEmail(
-    Token: any,
-    Email: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'sendAccountActivationEmail',
-          Token,
-          Email
-        );
-        return client['sendAccountActivationEmailAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'sendAccountActivationEmail',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getDisabilities(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getDisabilities');
-        return client['getDisabilitiesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getDisabilities',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getEstablishmentsBySearchDetails(
-    searchDetails: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getEstablishmentsBySearchDetails',
-          searchDetails
-        );
-        return client['getEstablishmentsBySearchDetailsAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getEstablishmentsBySearchDetails',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getRolesForUser(token: any, userNumber: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getRolesForUser', token, userNumber);
-        return client['getRolesForUserAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getRolesForUser',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async resetPasswordWithOldPassword(
-    sessionId: any,
-    oldPassword: any,
-    newPassword: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'resetPasswordWithOldPassword',
-          sessionId,
-          oldPassword,
-          newPassword
-        );
-        return client['resetPasswordWithOldPasswordAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'resetPasswordWithOldPassword',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getUsersPermissionUserGroupDTOs(
-    Token: any,
-    userNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getUsersPermissionUserGroupDTOs',
-          Token,
-          userNumber
-        );
-        return client['getUsersPermissionUserGroupDTOsAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getUsersPermissionUserGroupDTOs',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async deactivatePerson(token: any, userNumber: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('deactivatePerson', token, userNumber);
-        return client['deactivatePersonAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'deactivatePerson',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async logout(SessionId: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('logout', SessionId);
-        return client['logoutAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'logout',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async setPrivacyDTO(
-    token: any,
-    userNumber: any,
-    privacyDTO: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'setPrivacyDTO',
-          token,
-          userNumber,
-          privacyDTO
-        );
-        return client['setPrivacyDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'setPrivacyDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getChangesSince(Token: any, Since: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getChangesSince', Token, Since);
-        return client['getChangesSinceAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getChangesSince',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getGenders(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getGenders');
-        return client['getGendersAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getGenders',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async createPersonFromPersonDTO(
-    token: any,
-    person: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'createPersonFromPersonDTO',
-          token,
-          person
-        );
-        return client['createPersonFromPersonDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'createPersonFromPersonDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async loginWithAlternativeIdentifierECP(
-    Provider: any,
-    Username: any,
-    Password: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'loginWithAlternativeIdentifierECP',
-          Provider,
-          Username,
-          Password
-        );
-        return client['loginWithAlternativeIdentifierECPAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'loginWithAlternativeIdentifierECP',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async updateExpiredPassword(
-    token: any,
-    encryptedId: any,
-    oldPassword: any,
-    newPassword: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'updateExpiredPassword',
-          token,
-          encryptedId,
-          oldPassword,
-          newPassword
-        );
-        return client['updateExpiredPasswordAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'updateExpiredPassword',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getDataLookup(Name: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getDataLookup', Name);
-        return client['getDataLookupAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getDataLookup',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async updateAlternativeIdentifiersForUser(
-    Token: any,
-    AlternativeIdentifiers: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'updateAlternativeIdentifiersForUser',
-          Token,
-          AlternativeIdentifiers
-        );
-        return client['updateAlternativeIdentifiersForUserAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'updateAlternativeIdentifiersForUser',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async noLdapLogin(UserNumber: any, Password: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('noLdapLogin', UserNumber, Password);
-        return client['noLdapLoginAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'noLdapLogin',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getFrequentGenders(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getFrequentGenders');
-        return client['getFrequentGendersAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getFrequentGenders',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getEthnicities(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getEthnicities');
-        return client['getEthnicitiesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getEthnicities',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPeopleDetailsSinceDate(
-    Token: any,
-    Date: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPeopleDetailsSinceDate',
-          Token,
-          Date
-        );
-        return client['getBasicPeopleDetailsSinceDateAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPeopleDetailsSinceDate',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async createEstablishmentFromEstablishmentDTO(
-    token: any,
-    establishment: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'createEstablishmentFromEstablishmentDTO',
-          token,
-          establishment
-        );
-        return client['createEstablishmentFromEstablishmentDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'createEstablishmentFromEstablishmentDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPersonDetailsByEncryptedActivationId(
-    token: any,
-    encryptedActivationId: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPersonDetailsByEncryptedActivationId',
-          token,
-          encryptedActivationId
-        );
-        return client['getBasicPersonDetailsByEncryptedActivationIdAsync'](
-          argsObj
-        );
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPersonDetailsByEncryptedActivationId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async requestLinkExistingFedId(
-    token: any,
-    dob: any,
-    userNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'requestLinkExistingFedId',
-          token,
-          dob,
-          userNumber
-        );
-        return client['requestLinkExistingFedIdAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'requestLinkExistingFedId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPersonDetailsFromEmail(
-    Token: any,
-    Email: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPersonDetailsFromEmail',
-          Token,
-          Email
-        );
-        return client['getBasicPersonDetailsFromEmailAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPersonDetailsFromEmail',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async requestNewFedId(
-    token: any,
-    dob: any,
-    userNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'requestNewFedId',
-          token,
-          dob,
-          userNumber
-        );
-        return client['requestNewFedIdAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'requestNewFedId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async sendPasswordResetEmail(Token: any, Email: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'sendPasswordResetEmail',
-          Token,
-          Email
-        );
-        return client['sendPasswordResetEmailAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'sendPasswordResetEmail',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getAllEstablishmentDTOs(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getAllEstablishmentDTOs');
-        return client['getAllEstablishmentDTOsAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getAllEstablishmentDTOs',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getEstablishmentDTOsByQuery(searchQuery: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getEstablishmentDTOsByQuery',
-          searchQuery
-        );
-        return client['getEstablishmentDTOsByQueryAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getEstablishmentDTOsByQuery',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async acceptLatestDataProtectionAgreement(
-    token: any,
-    encryptedId: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'acceptLatestDataProtectionAgreement',
-          token,
-          encryptedId
-        );
-        return client['acceptLatestDataProtectionAgreementAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'acceptLatestDataProtectionAgreement',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async setMonitorDTO(
-    token: any,
-    userNumber: any,
-    monitorDTO: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'setMonitorDTO',
-          token,
-          userNumber,
-          monitorDTO
-        );
-        return client['setMonitorDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'setMonitorDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async activateAccountWithoutPassword(
-    encryptedActivationId: any,
-    ipAddress: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'activateAccountWithoutPassword',
-          encryptedActivationId,
-          ipAddress
-        );
-        return client['activateAccountWithoutPasswordAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'activateAccountWithoutPassword',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPersonDetailsFromFedId(
-    Token: any,
-    FedId: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPersonDetailsFromFedId',
-          Token,
-          FedId
-        );
-        return client['getBasicPersonDetailsFromFedIdAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPersonDetailsFromFedId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async activateAccount(
-    encryptedActivationId: any,
-    password: any,
-    ipAddress: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'activateAccount',
-          encryptedActivationId,
-          password,
-          ipAddress
-        );
-        return client['activateAccountAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'activateAccount',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPeopleDetailsFromUserNumbers(
-    Token: any,
-    UserNumbers: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPeopleDetailsFromUserNumbers',
-          Token,
-          UserNumbers
-        );
-        return client['getBasicPeopleDetailsFromUserNumbersAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPeopleDetailsFromUserNumbers',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getAllCountries(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getAllCountries');
-        return client['getAllCountriesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getAllCountries',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getSearchableBasicPersonDetailsFromEmail(
-    Token: any,
-    Email: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getSearchableBasicPersonDetailsFromEmail',
-          Token,
-          Email
-        );
-        return client['getSearchableBasicPersonDetailsFromEmailAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getSearchableBasicPersonDetailsFromEmail',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPersonDetailsFromUserNumber(
-    Token: any,
-    UserNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPersonDetailsFromUserNumber',
-          Token,
-          UserNumber
-        );
-        return client['getPersonDetailsFromUserNumberAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPersonDetailsFromUserNumber',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPersonDetailsFromEmail(Token: any, Email: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPersonDetailsFromEmail',
-          Token,
-          Email
-        );
-        return client['getPersonDetailsFromEmailAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPersonDetailsFromEmail',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async createFedId(
-    token: any,
-    fedIdUserName: any,
-    fedIdLoginPassword: any,
-    person: any,
-    status: any,
-    expiryDate: any,
-    fedIdDob: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'createFedId',
-          token,
-          fedIdUserName,
-          fedIdLoginPassword,
-          person,
-          status,
-          expiryDate,
-          fedIdDob
-        );
-        return client['createFedIdAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'createFedId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getAllFacilityNames(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getAllFacilityNames');
-        return client['getAllFacilityNamesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getAllFacilityNames',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPeopleDetailsFromEmails(
-    Token: any,
-    Emails: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPeopleDetailsFromEmails',
-          Token,
-          Emails
-        );
-        return client['getPeopleDetailsFromEmailsAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPeopleDetailsFromEmails',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async isAlternativeIdentifierActive(
-    Uuid: any,
-    Provider: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'isAlternativeIdentifierActive',
-          Uuid,
-          Provider
-        );
-        return client['isAlternativeIdentifierActiveAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'isAlternativeIdentifierActive',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async isAlternativeIdentifierLinked(
-    Uuid: any,
-    Provider: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'isAlternativeIdentifierLinked',
-          Uuid,
-          Provider
-        );
-        return client['isAlternativeIdentifierLinkedAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'isAlternativeIdentifierLinked',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async login(Account: any, Password: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('login', Account, Password);
-        return client['loginAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'login',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async linkAlternativeIdentifierToUser(
-    Token: any,
-    AlternativeIdentifier: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'linkAlternativeIdentifierToUser',
-          Token,
-          AlternativeIdentifier
-        );
-        return client['linkAlternativeIdentifierToUserAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'linkAlternativeIdentifierToUser',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getAlternativeIdentifiersForUser(
-    Token: any,
-    UserNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getAlternativeIdentifiersForUser',
-          Token,
-          UserNumber
-        );
-        return client['getAlternativeIdentifiersForUserAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getAlternativeIdentifiersForUser',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPeopleDetailsFromEstablishments(
-    Token: any,
-    SearchDetails: any[]
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPeopleDetailsFromEstablishments',
-          Token,
-          SearchDetails
-        );
-        return client['getBasicPeopleDetailsFromEstablishmentsAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPeopleDetailsFromEstablishments',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPersonDTOFromUserNumber(
-    token: any,
-    userNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPersonDTOFromUserNumber',
-          token,
-          userNumber
-        );
-        return client['getPersonDTOFromUserNumberAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPersonDTOFromUserNumber',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPersonDetailsByEncryptedPasswordResetId(
-    token: any,
-    encryptedResetId: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPersonDetailsByEncryptedPasswordResetId',
-          token,
-          encryptedResetId
-        );
-        return client['getBasicPersonDetailsByEncryptedPasswordResetIdAsync'](
-          argsObj
-        );
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPersonDetailsByEncryptedPasswordResetId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getAllEuCountries(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getAllEuCountries');
-        return client['getAllEuCountriesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getAllEuCountries',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async isAccountActive(UserNumber: any): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('isAccountActive', UserNumber);
-        return client['isAccountActiveAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'isAccountActive',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getAllPersonStatuses(): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj('getAllPersonStatuses');
-        return client['getAllPersonStatusesAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getAllPersonStatuses',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getBasicPersonDetailsFromUserNumber(
-    Token: any,
-    UserNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getBasicPersonDetailsFromUserNumber',
-          Token,
-          UserNumber
-        );
-        return client['getBasicPersonDetailsFromUserNumberAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getBasicPersonDetailsFromUserNumber',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getPeopleDetailsFromSurname(
-    Token: any,
-    Surname: any,
-    FuzzySearch: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getPeopleDetailsFromSurname',
-          Token,
-          Surname,
-          FuzzySearch
-        );
-        return client['getPeopleDetailsFromSurnameAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getPeopleDetailsFromSurname',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async getEmergencyContactDTO(
-    token: any,
-    userNumber: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'getEmergencyContactDTO',
-          token,
-          userNumber
-        );
-        return client['getEmergencyContactDTOAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'getEmergencyContactDTO',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async updateFedId(
-    token: any,
-    fedIdUserName: any,
-    fedIdLoginPassword: any,
-    objid: any,
-    objdomid: any,
-    expiryDate: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'updateFedId',
-          token,
-          fedIdUserName,
-          fedIdLoginPassword,
-          objid,
-          objdomid,
-          expiryDate
-        );
-        return client['updateFedIdAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'updateFedId',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  public async updatePersonByDTOFromSource(
-    token: any,
-    person: any,
-    updateSource: any
-  ): Promise<any> {
-    const refinedResult = soap
-      .createClientAsync(this.wsdlUrl)
-      .then((client: soap.Client) => {
-        const argsObj = this.makeArgsObj(
-          'updatePersonByDTOFromSource',
-          token,
-          person,
-          updateSource
-        );
-        return client['updatePersonByDTOFromSourceAsync'](argsObj);
-      })
-      .then((result) => {
-        return result[0];
-      })
-      .catch((result) => {
-        const response = result?.response;
-        const exceptionMessage = response?.data?.match(
-          '<faultstring>(.*)</faultstring>'
-        )[1];
-        logger.logWarn(
-          'A call to the UserOfficeWebService returned an exception: ',
-          {
-            exceptionMessage: exceptionMessage,
-            method: 'updatePersonByDTOFromSource',
-            serviceUrl: response?.config?.url,
-            rawResponse: response?.data,
-          }
-        );
-
-        throw exceptionMessage
-          ? exceptionMessage
-          : 'Error while calling UserOfficeWebService';
-      });
-    return refinedResult;
-  }
-
-  private makeArgsObj(functName: string, ...args: any[]) {
-    const argsObj: { [key: string]: any } = {};
-    const serviceDesc = this.wsdlDesc[Object.keys(this.wsdlDesc)[0]];
-    const collectionOfFunctions = serviceDesc[Object.keys(serviceDesc)[0]];
-    const argsDescr = collectionOfFunctions[functName];
-
-    Object.keys(argsDescr.input).forEach((element: string, index: number) => {
-      if (element !== 'targetNSAlias' && element !== 'targetNamespace') {
-        const argName: string = element.replace('[]', '');
-        argsObj[argName] = args[index];
+    import * as soap from 'soap';
+    import { logger } from '@user-office-software/duo-logger';
+    import { createHash } from 'crypto';
+
+    export default class UOWSSoapClient {
+      private static instance: UOWSSoapClient | undefined = undefined;
+      private wsdlUrl: string;
+      private client!: soap.Client;
+      private activeUowsRequests: Map<string, Promise<any>> = new Map();
+      private wsdlDesc: any = {"UserOfficeWebService":{"UserOfficeWebServicePort":{"getBasicPeopleDetailsFromSurname":{"input":{"Token":"xs:string","Surname":"xs:string","FuzzySearch":"xs:boolean","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getAgeRangeOptions":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPersonDetailsByEncryptedId":{"input":{"token":"xs:string","encryptedId":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getSearchableBasicPeopleDetailsFromSurname":{"input":{"Token":"xs:string","Surname":"xs:string","FuzzySearch":"xs:boolean","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"unlinkAlternativeIdentifierToUser":{"input":{"Token":"xs:string","AlternativeIdentifier":{"created":"xs:dateTime","createdBy":"xs:string","displayName":"xs:string","modified":"xs:dateTime","modifiedBy":"xs:string","provider":"xs:string","secretKey":"xs:string","thruDate":"xs:dateTime","userNumber":"xs:string","uuid":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPrivacyDTO":{"input":{"token":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"searchable":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getEstablishmentDTO":{"input":{"establishmentId":"xs:long","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"buildingName":"xs:string","buildingNumber":"xs:string","cityTown":"xs:string","country":"xs:string","countyProvinceState":"xs:string","deptAccronym":"xs:string","deptName":"xs:string","district":"xs:string","establishmentId":"xs:long","orgAcronym":"xs:string","orgName":"xs:string","poBox":"xs:string","postalCode":"xs:string","site":"xs:string","street":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPersonDetailsFromSessionId":{"input":{"SessionId":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","emergencyContact":"xs:string","establishmentId":"xs:string","familyName":"xs:string","fedId":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"mobilePhone":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","status":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getInductionsFacilityAwarenessForUser":{"input":{"arg0":"xs:string","arg1":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"facilities[]":"xs:string","inductions[]":{"course":"xs:string","dateTaken":"xs:dateTime","id":"xs:long","modifiedBy":"xs:string","modifiedByName":"xs:string","modifiedDate":"xs:dateTime","thruDate":"xs:dateTime","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPersonsFacilities":{"input":{"token":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getEstablishmentDTOsBySearchDetails":{"input":{"searchDetails[]":{"departmentName":"xs:string","organisationName":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"buildingName":"xs:string","buildingNumber":"xs:string","cityTown":"xs:string","country":"xs:string","countyProvinceState":"xs:string","deptAccronym":"xs:string","deptName":"xs:string","district":"xs:string","establishmentId":"xs:long","orgAcronym":"xs:string","orgName":"xs:string","poBox":"xs:string","postalCode":"xs:string","site":"xs:string","street":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPeopleDetailsFromUserNumbers":{"input":{"Token":"xs:string","UserNumbers[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","emergencyContact":"xs:string","establishmentId":"xs:string","familyName":"xs:string","fedId":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"mobilePhone":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","status":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getSearchableBasicPersonDetailsFromUserNumber":{"input":{"Token":"xs:string","UserNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"deleteEstablishmentById":{"input":{"Token":"xs:string","EstablishmentId":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getAllTitles":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"updatePersonByDTO":{"input":{"token":"xs:string","person":{"deactivated":"xs:boolean","displayName":"xs:string","dpaDate":"xs:dateTime","email":"xs:string","establishmentId":"xs:long","familyName":"xs:string","fedId":"xs:string","firstName":"xs:string","firstNameKnownAs":"xs:string","fromDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"fullName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"marketingEmail":"xs:string","mobilePhone":"xs:string","resetPasswordDate":"xs:dateTime","rid":"xs:long","status":"xs:string","subscribedToMarketingEmails":"xs:boolean","thruDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPeopleDetailsFromEmails":{"input":{"Token":"xs:string","Emails[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"loginWithAlternativeIdentifier":{"input":{"SystemSessionId":"xs:string","Uuid":"xs:string","Provider":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPersonDTOByMarketingEmail":{"input":{"token":"xs:string","marketingEmail":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"deactivated":"xs:boolean","displayName":"xs:string","dpaDate":"xs:dateTime","email":"xs:string","establishmentId":"xs:long","familyName":"xs:string","fedId":"xs:string","firstName":"xs:string","firstNameKnownAs":"xs:string","fromDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"fullName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"marketingEmail":"xs:string","mobilePhone":"xs:string","resetPasswordDate":"xs:dateTime","rid":"xs:long","status":"xs:string","subscribedToMarketingEmails":"xs:boolean","thruDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getSearchableBasicPeopleDetailsFromUserNumbers":{"input":{"Token":"xs:string","UserNumbers[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"isTokenValid":{"input":{"Token":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:boolean","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getSearchableBasicPeopleDetailsFromEmails":{"input":{"Token":"xs:string","Emails[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"updatePersonsFacilities":{"input":{"token":"xs:string","userNumber":"xs:string","facilities[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getMonitorDTO":{"input":{"token":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"ageOption":"xs:string","disability":"xs:string","ethnicity":"xs:string","gender":"xs:string","optIn":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"resetPassword":{"input":{"encryptedResetId":"xs:string","password":"xs:string","ipAddress":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getDataUsages":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"name":"xs:string","value":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"updateEmergencyContactDTO":{"input":{"token":"xs:string","userNumber":"xs:string","emergencyContactDTO":{"contact":"xs:string","contactId":"xs:long","dateAdded":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"sendAccountActivationEmail":{"input":{"Token":"xs:string","Email":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getDisabilities":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getEstablishmentsBySearchDetails":{"input":{"searchDetails[]":{"departmentName":"xs:string","organisationName":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"departmentAcronym":"xs:string","departmentName":"xs:string","departmentUrl":"xs:string","establishmentId":"xs:long","groupAcronym":"xs:string","groupName":"xs:string","organisationAcronym":"xs:string","organisationName":"xs:string","organisationType":"xs:string","organisationUrl":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getRolesForUser":{"input":{"token":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"name":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"resetPasswordWithOldPassword":{"input":{"sessionId":"xs:string","oldPassword":"xs:string","newPassword":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getUsersPermissionUserGroupDTOs":{"input":{"Token":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"comments":"xs:string","groupName":"xs:string","id":"xs:long","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"deactivatePerson":{"input":{"token":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"logout":{"input":{"SessionId":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"setPrivacyDTO":{"input":{"token":"xs:string","userNumber":"xs:string","privacyDTO":{"searchable":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getChangesSince":{"input":{"Token":"xs:string","Since":"xs:dateTime","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"comments":"xs:string","deactivated":"xs:boolean","dpaDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"email":"xs:string","establishmentId":"xs:long","familyName":"xs:string","fedId":"xs:string","firstNameKnownAs":"xs:string","fromDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"givenName":"xs:string","initials":"xs:string","isisSalt":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastpwdreset":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"marketingEmail":"xs:string","mobilePhone":"xs:string","monitorId":"xs:long","newUserNumber":"xs:string","privacyId":"xs:long","rid":"xs:long","sha2":"xs:string","status":"xs:string","subscribedToMarketingEmails":"xs:boolean","thruDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"title":"xs:string","updated":"xs:string","userNumber":"xs:string","verified":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getGenders":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"createPersonFromPersonDTO":{"input":{"token":"xs:string","person":{"deactivated":"xs:boolean","displayName":"xs:string","dpaDate":"xs:dateTime","email":"xs:string","establishmentId":"xs:long","familyName":"xs:string","fedId":"xs:string","firstName":"xs:string","firstNameKnownAs":"xs:string","fromDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"fullName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"marketingEmail":"xs:string","mobilePhone":"xs:string","resetPasswordDate":"xs:dateTime","rid":"xs:long","status":"xs:string","subscribedToMarketingEmails":"xs:boolean","thruDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"loginWithAlternativeIdentifierECP":{"input":{"Provider":"xs:string","Username":"xs:string","Password":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"updateExpiredPassword":{"input":{"token":"xs:string","encryptedId":"xs:string","oldPassword":"xs:string","newPassword":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getDataLookup":{"input":{"Name":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"updateAlternativeIdentifiersForUser":{"input":{"Token":"xs:string","AlternativeIdentifiers[]":{"created":"xs:dateTime","createdBy":"xs:string","displayName":"xs:string","modified":"xs:dateTime","modifiedBy":"xs:string","provider":"xs:string","secretKey":"xs:string","thruDate":"xs:dateTime","userNumber":"xs:string","uuid":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"noLdapLogin":{"input":{"UserNumber":"xs:string","Password":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getFrequentGenders":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getEthnicities":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPeopleDetailsSinceDate":{"input":{"Token":"xs:string","Date":"xs:dateTime","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"createEstablishmentFromEstablishmentDTO":{"input":{"token":"xs:string","establishment":{"buildingName":"xs:string","buildingNumber":"xs:string","cityTown":"xs:string","country":"xs:string","countyProvinceState":"xs:string","deptAccronym":"xs:string","deptName":"xs:string","district":"xs:string","establishmentId":"xs:long","orgAcronym":"xs:string","orgName":"xs:string","poBox":"xs:string","postalCode":"xs:string","site":"xs:string","street":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:long","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPersonDetailsByEncryptedActivationId":{"input":{"token":"xs:string","encryptedActivationId":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"requestLinkExistingFedId":{"input":{"token":"xs:string","dob":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPersonDetailsFromEmail":{"input":{"Token":"xs:string","Email":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"requestNewFedId":{"input":{"token":"xs:string","dob":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"sendPasswordResetEmail":{"input":{"Token":"xs:string","Email":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getAllEstablishmentDTOs":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"buildingName":"xs:string","buildingNumber":"xs:string","cityTown":"xs:string","country":"xs:string","countyProvinceState":"xs:string","deptAccronym":"xs:string","deptName":"xs:string","district":"xs:string","establishmentId":"xs:long","orgAcronym":"xs:string","orgName":"xs:string","poBox":"xs:string","postalCode":"xs:string","site":"xs:string","street":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getEstablishmentDTOsByQuery":{"input":{"searchQuery":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"buildingName":"xs:string","buildingNumber":"xs:string","cityTown":"xs:string","country":"xs:string","countyProvinceState":"xs:string","deptAccronym":"xs:string","deptName":"xs:string","district":"xs:string","establishmentId":"xs:long","orgAcronym":"xs:string","orgName":"xs:string","poBox":"xs:string","postalCode":"xs:string","site":"xs:string","street":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"acceptLatestDataProtectionAgreement":{"input":{"token":"xs:string","encryptedId":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"setMonitorDTO":{"input":{"token":"xs:string","userNumber":"xs:string","monitorDTO":{"ageOption":"xs:string","disability":"xs:string","ethnicity":"xs:string","gender":"xs:string","optIn":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"activateAccountWithoutPassword":{"input":{"encryptedActivationId":"xs:string","ipAddress":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPersonDetailsFromFedId":{"input":{"Token":"xs:string","FedId":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"activateAccount":{"input":{"encryptedActivationId":"xs:string","password":"xs:string","ipAddress":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPeopleDetailsFromUserNumbers":{"input":{"Token":"xs:string","UserNumbers[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getAllCountries":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getSearchableBasicPersonDetailsFromEmail":{"input":{"Token":"xs:string","Email":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPersonDetailsFromUserNumber":{"input":{"Token":"xs:string","UserNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","emergencyContact":"xs:string","establishmentId":"xs:string","familyName":"xs:string","fedId":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"mobilePhone":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","status":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPersonDetailsFromEmail":{"input":{"Token":"xs:string","Email":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","emergencyContact":"xs:string","establishmentId":"xs:string","familyName":"xs:string","fedId":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"mobilePhone":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","status":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"createFedId":{"input":{"token":"xs:string","fedIdUserName":"xs:string","fedIdLoginPassword":"xs:string","person":{"deactivated":"xs:boolean","displayName":"xs:string","dpaDate":"xs:dateTime","email":"xs:string","establishmentId":"xs:long","familyName":"xs:string","fedId":"xs:string","firstName":"xs:string","firstNameKnownAs":"xs:string","fromDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"fullName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"marketingEmail":"xs:string","mobilePhone":"xs:string","resetPasswordDate":"xs:dateTime","rid":"xs:long","status":"xs:string","subscribedToMarketingEmails":"xs:boolean","thruDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"status":"xs:string","expiryDate":"xs:dateTime","fedIdDob":"xs:dateTime","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getAllFacilityNames":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPeopleDetailsFromEmails":{"input":{"Token":"xs:string","Emails[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","emergencyContact":"xs:string","establishmentId":"xs:string","familyName":"xs:string","fedId":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"mobilePhone":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","status":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"isAlternativeIdentifierActive":{"input":{"Uuid":"xs:string","Provider":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:boolean","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"isAlternativeIdentifierLinked":{"input":{"Uuid":"xs:string","Provider":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:boolean","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"login":{"input":{"Account":"xs:string","Password":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"linkAlternativeIdentifierToUser":{"input":{"Token":"xs:string","AlternativeIdentifier":{"created":"xs:dateTime","createdBy":"xs:string","displayName":"xs:string","modified":"xs:dateTime","modifiedBy":"xs:string","provider":"xs:string","secretKey":"xs:string","thruDate":"xs:dateTime","userNumber":"xs:string","uuid":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getAlternativeIdentifiersForUser":{"input":{"Token":"xs:string","UserNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"created":"xs:dateTime","createdBy":"xs:string","displayName":"xs:string","modified":"xs:dateTime","modifiedBy":"xs:string","provider":"xs:string","secretKey":"xs:string","thruDate":"xs:dateTime","userNumber":"xs:string","uuid":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPeopleDetailsFromEstablishments":{"input":{"Token":"xs:string","SearchDetails[]":{"departmentName":"xs:string","organisationName":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPersonDTOFromUserNumber":{"input":{"token":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"deactivated":"xs:boolean","displayName":"xs:string","dpaDate":"xs:dateTime","email":"xs:string","establishmentId":"xs:long","familyName":"xs:string","fedId":"xs:string","firstName":"xs:string","firstNameKnownAs":"xs:string","fromDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"fullName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"marketingEmail":"xs:string","mobilePhone":"xs:string","resetPasswordDate":"xs:dateTime","rid":"xs:long","status":"xs:string","subscribedToMarketingEmails":"xs:boolean","thruDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPersonDetailsByEncryptedPasswordResetId":{"input":{"token":"xs:string","encryptedResetId":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getAllEuCountries":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"isAccountActive":{"input":{"UserNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:boolean","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getAllPersonStatuses":{"input":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getBasicPersonDetailsFromUserNumber":{"input":{"Token":"xs:string","UserNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","establishmentId":"xs:string","familyName":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getPeopleDetailsFromSurname":{"input":{"Token":"xs:string","Surname":"xs:string","FuzzySearch":"xs:boolean","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return[]":{"country":"xs:string","deptAcronym":"xs:string","deptName":"xs:string","displayName":"xs:string","email":"xs:string","emergencyContact":"xs:string","establishmentId":"xs:string","familyName":"xs:string","fedId":"xs:string","firstNameKnownAs":"xs:string","fullName":"xs:string","givenName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"mobilePhone":"xs:string","orgAcronym":"xs:string","orgName":"xs:string","status":"xs:string","title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"getEmergencyContactDTO":{"input":{"token":"xs:string","userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":{"contact":"xs:string","contactId":"xs:long","dateAdded":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"userNumber":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"updateFedId":{"input":{"token":"xs:string","fedIdUserName":"xs:string","fedIdLoginPassword":"xs:string","objid":"xs:string","objdomid":"xs:string","expiryDate":"xs:dateTime","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"return":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}},"updatePersonByDTOFromSource":{"input":{"token":"xs:string","person":{"deactivated":"xs:boolean","displayName":"xs:string","dpaDate":"xs:dateTime","email":"xs:string","establishmentId":"xs:long","familyName":"xs:string","fedId":"xs:string","firstName":"xs:string","firstNameKnownAs":"xs:string","fromDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"fullName":"xs:string","initials":"xs:string","joinedDate":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"lastAccessTime":{"nanos":"xs:int","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"marketingEmail":"xs:string","mobilePhone":"xs:string","resetPasswordDate":"xs:dateTime","rid":"xs:long","status":"xs:string","subscribedToMarketingEmails":"xs:boolean","thruDate":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"title":"xs:string","userNumber":"xs:string","workPhone":"xs:string","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"updateSource":"requestSourceDTO|xs:string|DEFAULT,MAILING_API","targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"},"output":{"targetNSAlias":"tns","targetNamespace":"http://webservice.UserOffice.stfc.com/"}}}}};
+
+      static getInstance(): UOWSSoapClient {
+        if (!this.instance) {
+          this.instance = new UOWSSoapClient(process.env.EXTERNAL_AUTH_SERVICE_URL);
+        }
+
+        return this.instance;
       }
-    });
-    return argsObj;
-  }
-}
+
+         private constructor(wsdlUrl?: string) {
+              if(wsdlUrl == null)
+                  this.wsdlUrl = 'https://devapis.facilities.rl.ac.uk/ws/UserOfficeWebService?wsdl';
+              else
+                  this.wsdlUrl = wsdlUrl;
+
+              this.setClient();
+          }
+
+
+
+      private setClient() {
+        logger.logInfo('Attempting to create UOWS client', {});
+        soap.createClient(this.wsdlUrl, (error, client) => {
+          if (error) {
+            logger.logError('An error occurred while creating the UOWS client', {error: error});
+            setTimeout(() => { this.setClient() }, 10000);
+            return;
+          }
+          logger.logInfo('Created UOWS client', {});
+          this.client = client
+        });
+      }
+
+          public async getBasicPeopleDetailsFromSurname(Token: any, Surname: any, FuzzySearch: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPeopleDetailsFromSurname', Token, Surname, FuzzySearch);
+                  const requestId = createHash('sha1').update('getBasicPeopleDetailsFromSurname' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPeopleDetailsFromSurnameAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPeopleDetailsFromSurname',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getAgeRangeOptions() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getAgeRangeOptions');
+                  const requestId = createHash('sha1').update('getAgeRangeOptions' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getAgeRangeOptionsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getAgeRangeOptions',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPersonDetailsByEncryptedId(token: any, encryptedId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPersonDetailsByEncryptedId', token, encryptedId);
+                  const requestId = createHash('sha1').update('getBasicPersonDetailsByEncryptedId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPersonDetailsByEncryptedIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPersonDetailsByEncryptedId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getSearchableBasicPeopleDetailsFromSurname(Token: any, Surname: any, FuzzySearch: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getSearchableBasicPeopleDetailsFromSurname', Token, Surname, FuzzySearch);
+                  const requestId = createHash('sha1').update('getSearchableBasicPeopleDetailsFromSurname' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getSearchableBasicPeopleDetailsFromSurnameAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getSearchableBasicPeopleDetailsFromSurname',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async unlinkAlternativeIdentifierToUser(Token: any, AlternativeIdentifier: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('unlinkAlternativeIdentifierToUser', Token, AlternativeIdentifier);
+                  const requestId = createHash('sha1').update('unlinkAlternativeIdentifierToUser' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['unlinkAlternativeIdentifierToUserAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'unlinkAlternativeIdentifierToUser',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPrivacyDTO(token: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPrivacyDTO', token, userNumber);
+                  const requestId = createHash('sha1').update('getPrivacyDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPrivacyDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPrivacyDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getEstablishmentDTO(establishmentId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getEstablishmentDTO', establishmentId);
+                  const requestId = createHash('sha1').update('getEstablishmentDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getEstablishmentDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getEstablishmentDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPersonDetailsFromSessionId(SessionId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPersonDetailsFromSessionId', SessionId);
+                  const requestId = createHash('sha1').update('getPersonDetailsFromSessionId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPersonDetailsFromSessionIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPersonDetailsFromSessionId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getInductionsFacilityAwarenessForUser(arg0: any, arg1: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getInductionsFacilityAwarenessForUser', arg0, arg1);
+                  const requestId = createHash('sha1').update('getInductionsFacilityAwarenessForUser' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getInductionsFacilityAwarenessForUserAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getInductionsFacilityAwarenessForUser',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPersonsFacilities(token: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPersonsFacilities', token, userNumber);
+                  const requestId = createHash('sha1').update('getPersonsFacilities' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPersonsFacilitiesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPersonsFacilities',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getEstablishmentDTOsBySearchDetails(searchDetails: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getEstablishmentDTOsBySearchDetails', searchDetails);
+                  const requestId = createHash('sha1').update('getEstablishmentDTOsBySearchDetails' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getEstablishmentDTOsBySearchDetailsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getEstablishmentDTOsBySearchDetails',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPeopleDetailsFromUserNumbers(Token: any, UserNumbers: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPeopleDetailsFromUserNumbers', Token, UserNumbers);
+                  const requestId = createHash('sha1').update('getPeopleDetailsFromUserNumbers' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPeopleDetailsFromUserNumbersAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPeopleDetailsFromUserNumbers',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getSearchableBasicPersonDetailsFromUserNumber(Token: any, UserNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getSearchableBasicPersonDetailsFromUserNumber', Token, UserNumber);
+                  const requestId = createHash('sha1').update('getSearchableBasicPersonDetailsFromUserNumber' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getSearchableBasicPersonDetailsFromUserNumberAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getSearchableBasicPersonDetailsFromUserNumber',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async deleteEstablishmentById(Token: any, EstablishmentId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('deleteEstablishmentById', Token, EstablishmentId);
+                  const requestId = createHash('sha1').update('deleteEstablishmentById' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['deleteEstablishmentByIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'deleteEstablishmentById',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getAllTitles() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getAllTitles');
+                  const requestId = createHash('sha1').update('getAllTitles' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getAllTitlesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getAllTitles',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async updatePersonByDTO(token: any, person: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('updatePersonByDTO', token, person);
+                  const requestId = createHash('sha1').update('updatePersonByDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['updatePersonByDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'updatePersonByDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPeopleDetailsFromEmails(Token: any, Emails: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPeopleDetailsFromEmails', Token, Emails);
+                  const requestId = createHash('sha1').update('getBasicPeopleDetailsFromEmails' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPeopleDetailsFromEmailsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPeopleDetailsFromEmails',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async loginWithAlternativeIdentifier(SystemSessionId: any, Uuid: any, Provider: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('loginWithAlternativeIdentifier', SystemSessionId, Uuid, Provider);
+                  const requestId = createHash('sha1').update('loginWithAlternativeIdentifier' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['loginWithAlternativeIdentifierAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'loginWithAlternativeIdentifier',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPersonDTOByMarketingEmail(token: any, marketingEmail: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPersonDTOByMarketingEmail', token, marketingEmail);
+                  const requestId = createHash('sha1').update('getPersonDTOByMarketingEmail' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPersonDTOByMarketingEmailAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPersonDTOByMarketingEmail',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getSearchableBasicPeopleDetailsFromUserNumbers(Token: any, UserNumbers: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getSearchableBasicPeopleDetailsFromUserNumbers', Token, UserNumbers);
+                  const requestId = createHash('sha1').update('getSearchableBasicPeopleDetailsFromUserNumbers' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getSearchableBasicPeopleDetailsFromUserNumbersAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getSearchableBasicPeopleDetailsFromUserNumbers',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async isTokenValid(Token: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('isTokenValid', Token);
+                  const requestId = createHash('sha1').update('isTokenValid' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['isTokenValidAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'isTokenValid',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getSearchableBasicPeopleDetailsFromEmails(Token: any, Emails: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getSearchableBasicPeopleDetailsFromEmails', Token, Emails);
+                  const requestId = createHash('sha1').update('getSearchableBasicPeopleDetailsFromEmails' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getSearchableBasicPeopleDetailsFromEmailsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getSearchableBasicPeopleDetailsFromEmails',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async updatePersonsFacilities(token: any, userNumber: any, facilities: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('updatePersonsFacilities', token, userNumber, facilities);
+                  const requestId = createHash('sha1').update('updatePersonsFacilities' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['updatePersonsFacilitiesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'updatePersonsFacilities',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getMonitorDTO(token: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getMonitorDTO', token, userNumber);
+                  const requestId = createHash('sha1').update('getMonitorDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getMonitorDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getMonitorDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async resetPassword(encryptedResetId: any, password: any, ipAddress: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('resetPassword', encryptedResetId, password, ipAddress);
+                  const requestId = createHash('sha1').update('resetPassword' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['resetPasswordAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'resetPassword',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getDataUsages() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getDataUsages');
+                  const requestId = createHash('sha1').update('getDataUsages' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getDataUsagesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getDataUsages',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async updateEmergencyContactDTO(token: any, userNumber: any, emergencyContactDTO: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('updateEmergencyContactDTO', token, userNumber, emergencyContactDTO);
+                  const requestId = createHash('sha1').update('updateEmergencyContactDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['updateEmergencyContactDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'updateEmergencyContactDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async sendAccountActivationEmail(Token: any, Email: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('sendAccountActivationEmail', Token, Email);
+                  const requestId = createHash('sha1').update('sendAccountActivationEmail' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['sendAccountActivationEmailAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'sendAccountActivationEmail',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getDisabilities() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getDisabilities');
+                  const requestId = createHash('sha1').update('getDisabilities' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getDisabilitiesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getDisabilities',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getEstablishmentsBySearchDetails(searchDetails: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getEstablishmentsBySearchDetails', searchDetails);
+                  const requestId = createHash('sha1').update('getEstablishmentsBySearchDetails' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getEstablishmentsBySearchDetailsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getEstablishmentsBySearchDetails',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getRolesForUser(token: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getRolesForUser', token, userNumber);
+                  const requestId = createHash('sha1').update('getRolesForUser' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getRolesForUserAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getRolesForUser',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async resetPasswordWithOldPassword(sessionId: any, oldPassword: any, newPassword: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('resetPasswordWithOldPassword', sessionId, oldPassword, newPassword);
+                  const requestId = createHash('sha1').update('resetPasswordWithOldPassword' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['resetPasswordWithOldPasswordAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'resetPasswordWithOldPassword',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getUsersPermissionUserGroupDTOs(Token: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getUsersPermissionUserGroupDTOs', Token, userNumber);
+                  const requestId = createHash('sha1').update('getUsersPermissionUserGroupDTOs' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getUsersPermissionUserGroupDTOsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getUsersPermissionUserGroupDTOs',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async deactivatePerson(token: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('deactivatePerson', token, userNumber);
+                  const requestId = createHash('sha1').update('deactivatePerson' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['deactivatePersonAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'deactivatePerson',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async logout(SessionId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('logout', SessionId);
+                  const requestId = createHash('sha1').update('logout' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['logoutAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'logout',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async setPrivacyDTO(token: any, userNumber: any, privacyDTO: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('setPrivacyDTO', token, userNumber, privacyDTO);
+                  const requestId = createHash('sha1').update('setPrivacyDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['setPrivacyDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'setPrivacyDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getChangesSince(Token: any, Since: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getChangesSince', Token, Since);
+                  const requestId = createHash('sha1').update('getChangesSince' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getChangesSinceAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getChangesSince',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getGenders() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getGenders');
+                  const requestId = createHash('sha1').update('getGenders' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getGendersAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getGenders',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async createPersonFromPersonDTO(token: any, person: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('createPersonFromPersonDTO', token, person);
+                  const requestId = createHash('sha1').update('createPersonFromPersonDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['createPersonFromPersonDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'createPersonFromPersonDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async loginWithAlternativeIdentifierECP(Provider: any, Username: any, Password: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('loginWithAlternativeIdentifierECP', Provider, Username, Password);
+                  const requestId = createHash('sha1').update('loginWithAlternativeIdentifierECP' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['loginWithAlternativeIdentifierECPAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'loginWithAlternativeIdentifierECP',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async updateExpiredPassword(token: any, encryptedId: any, oldPassword: any, newPassword: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('updateExpiredPassword', token, encryptedId, oldPassword, newPassword);
+                  const requestId = createHash('sha1').update('updateExpiredPassword' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['updateExpiredPasswordAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'updateExpiredPassword',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getDataLookup(Name: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getDataLookup', Name);
+                  const requestId = createHash('sha1').update('getDataLookup' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getDataLookupAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getDataLookup',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async updateAlternativeIdentifiersForUser(Token: any, AlternativeIdentifiers: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('updateAlternativeIdentifiersForUser', Token, AlternativeIdentifiers);
+                  const requestId = createHash('sha1').update('updateAlternativeIdentifiersForUser' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['updateAlternativeIdentifiersForUserAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'updateAlternativeIdentifiersForUser',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async noLdapLogin(UserNumber: any, Password: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('noLdapLogin', UserNumber, Password);
+                  const requestId = createHash('sha1').update('noLdapLogin' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['noLdapLoginAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'noLdapLogin',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getFrequentGenders() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getFrequentGenders');
+                  const requestId = createHash('sha1').update('getFrequentGenders' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getFrequentGendersAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getFrequentGenders',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getEthnicities() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getEthnicities');
+                  const requestId = createHash('sha1').update('getEthnicities' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getEthnicitiesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getEthnicities',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPeopleDetailsSinceDate(Token: any, Date: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPeopleDetailsSinceDate', Token, Date);
+                  const requestId = createHash('sha1').update('getBasicPeopleDetailsSinceDate' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPeopleDetailsSinceDateAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPeopleDetailsSinceDate',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async createEstablishmentFromEstablishmentDTO(token: any, establishment: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('createEstablishmentFromEstablishmentDTO', token, establishment);
+                  const requestId = createHash('sha1').update('createEstablishmentFromEstablishmentDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['createEstablishmentFromEstablishmentDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'createEstablishmentFromEstablishmentDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPersonDetailsByEncryptedActivationId(token: any, encryptedActivationId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPersonDetailsByEncryptedActivationId', token, encryptedActivationId);
+                  const requestId = createHash('sha1').update('getBasicPersonDetailsByEncryptedActivationId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPersonDetailsByEncryptedActivationIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPersonDetailsByEncryptedActivationId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async requestLinkExistingFedId(token: any, dob: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('requestLinkExistingFedId', token, dob, userNumber);
+                  const requestId = createHash('sha1').update('requestLinkExistingFedId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['requestLinkExistingFedIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'requestLinkExistingFedId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPersonDetailsFromEmail(Token: any, Email: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPersonDetailsFromEmail', Token, Email);
+                  const requestId = createHash('sha1').update('getBasicPersonDetailsFromEmail' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPersonDetailsFromEmailAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPersonDetailsFromEmail',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async requestNewFedId(token: any, dob: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('requestNewFedId', token, dob, userNumber);
+                  const requestId = createHash('sha1').update('requestNewFedId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['requestNewFedIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'requestNewFedId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async sendPasswordResetEmail(Token: any, Email: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('sendPasswordResetEmail', Token, Email);
+                  const requestId = createHash('sha1').update('sendPasswordResetEmail' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['sendPasswordResetEmailAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'sendPasswordResetEmail',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getAllEstablishmentDTOs() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getAllEstablishmentDTOs');
+                  const requestId = createHash('sha1').update('getAllEstablishmentDTOs' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getAllEstablishmentDTOsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getAllEstablishmentDTOs',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getEstablishmentDTOsByQuery(searchQuery: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getEstablishmentDTOsByQuery', searchQuery);
+                  const requestId = createHash('sha1').update('getEstablishmentDTOsByQuery' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getEstablishmentDTOsByQueryAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getEstablishmentDTOsByQuery',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async acceptLatestDataProtectionAgreement(token: any, encryptedId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('acceptLatestDataProtectionAgreement', token, encryptedId);
+                  const requestId = createHash('sha1').update('acceptLatestDataProtectionAgreement' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['acceptLatestDataProtectionAgreementAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'acceptLatestDataProtectionAgreement',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async setMonitorDTO(token: any, userNumber: any, monitorDTO: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('setMonitorDTO', token, userNumber, monitorDTO);
+                  const requestId = createHash('sha1').update('setMonitorDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['setMonitorDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'setMonitorDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async activateAccountWithoutPassword(encryptedActivationId: any, ipAddress: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('activateAccountWithoutPassword', encryptedActivationId, ipAddress);
+                  const requestId = createHash('sha1').update('activateAccountWithoutPassword' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['activateAccountWithoutPasswordAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'activateAccountWithoutPassword',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPersonDetailsFromFedId(Token: any, FedId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPersonDetailsFromFedId', Token, FedId);
+                  const requestId = createHash('sha1').update('getBasicPersonDetailsFromFedId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPersonDetailsFromFedIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPersonDetailsFromFedId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async activateAccount(encryptedActivationId: any, password: any, ipAddress: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('activateAccount', encryptedActivationId, password, ipAddress);
+                  const requestId = createHash('sha1').update('activateAccount' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['activateAccountAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'activateAccount',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPeopleDetailsFromUserNumbers(Token: any, UserNumbers: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPeopleDetailsFromUserNumbers', Token, UserNumbers);
+                  const requestId = createHash('sha1').update('getBasicPeopleDetailsFromUserNumbers' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPeopleDetailsFromUserNumbersAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPeopleDetailsFromUserNumbers',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getAllCountries() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getAllCountries');
+                  const requestId = createHash('sha1').update('getAllCountries' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getAllCountriesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getAllCountries',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getSearchableBasicPersonDetailsFromEmail(Token: any, Email: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getSearchableBasicPersonDetailsFromEmail', Token, Email);
+                  const requestId = createHash('sha1').update('getSearchableBasicPersonDetailsFromEmail' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getSearchableBasicPersonDetailsFromEmailAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getSearchableBasicPersonDetailsFromEmail',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPersonDetailsFromUserNumber(Token: any, UserNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPersonDetailsFromUserNumber', Token, UserNumber);
+                  const requestId = createHash('sha1').update('getPersonDetailsFromUserNumber' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPersonDetailsFromUserNumberAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPersonDetailsFromUserNumber',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPersonDetailsFromEmail(Token: any, Email: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPersonDetailsFromEmail', Token, Email);
+                  const requestId = createHash('sha1').update('getPersonDetailsFromEmail' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPersonDetailsFromEmailAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPersonDetailsFromEmail',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async createFedId(token: any, fedIdUserName: any, fedIdLoginPassword: any, person: any, status: any, expiryDate: any, fedIdDob: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('createFedId', token, fedIdUserName, fedIdLoginPassword, person, status, expiryDate, fedIdDob);
+                  const requestId = createHash('sha1').update('createFedId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['createFedIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'createFedId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getAllFacilityNames() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getAllFacilityNames');
+                  const requestId = createHash('sha1').update('getAllFacilityNames' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getAllFacilityNamesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getAllFacilityNames',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPeopleDetailsFromEmails(Token: any, Emails: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPeopleDetailsFromEmails', Token, Emails);
+                  const requestId = createHash('sha1').update('getPeopleDetailsFromEmails' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPeopleDetailsFromEmailsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPeopleDetailsFromEmails',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async isAlternativeIdentifierActive(Uuid: any, Provider: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('isAlternativeIdentifierActive', Uuid, Provider);
+                  const requestId = createHash('sha1').update('isAlternativeIdentifierActive' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['isAlternativeIdentifierActiveAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'isAlternativeIdentifierActive',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async isAlternativeIdentifierLinked(Uuid: any, Provider: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('isAlternativeIdentifierLinked', Uuid, Provider);
+                  const requestId = createHash('sha1').update('isAlternativeIdentifierLinked' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['isAlternativeIdentifierLinkedAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'isAlternativeIdentifierLinked',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async login(Account: any, Password: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('login', Account, Password);
+                  const requestId = createHash('sha1').update('login' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['loginAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'login',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async linkAlternativeIdentifierToUser(Token: any, AlternativeIdentifier: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('linkAlternativeIdentifierToUser', Token, AlternativeIdentifier);
+                  const requestId = createHash('sha1').update('linkAlternativeIdentifierToUser' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['linkAlternativeIdentifierToUserAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'linkAlternativeIdentifierToUser',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getAlternativeIdentifiersForUser(Token: any, UserNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getAlternativeIdentifiersForUser', Token, UserNumber);
+                  const requestId = createHash('sha1').update('getAlternativeIdentifiersForUser' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getAlternativeIdentifiersForUserAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getAlternativeIdentifiersForUser',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPeopleDetailsFromEstablishments(Token: any, SearchDetails: any[]) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPeopleDetailsFromEstablishments', Token, SearchDetails);
+                  const requestId = createHash('sha1').update('getBasicPeopleDetailsFromEstablishments' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPeopleDetailsFromEstablishmentsAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPeopleDetailsFromEstablishments',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPersonDTOFromUserNumber(token: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPersonDTOFromUserNumber', token, userNumber);
+                  const requestId = createHash('sha1').update('getPersonDTOFromUserNumber' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPersonDTOFromUserNumberAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPersonDTOFromUserNumber',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPersonDetailsByEncryptedPasswordResetId(token: any, encryptedResetId: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPersonDetailsByEncryptedPasswordResetId', token, encryptedResetId);
+                  const requestId = createHash('sha1').update('getBasicPersonDetailsByEncryptedPasswordResetId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPersonDetailsByEncryptedPasswordResetIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPersonDetailsByEncryptedPasswordResetId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getAllEuCountries() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getAllEuCountries');
+                  const requestId = createHash('sha1').update('getAllEuCountries' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getAllEuCountriesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getAllEuCountries',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async isAccountActive(UserNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('isAccountActive', UserNumber);
+                  const requestId = createHash('sha1').update('isAccountActive' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['isAccountActiveAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'isAccountActive',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getAllPersonStatuses() : Promise<any> {
+                  const argsObj = this.makeArgsObj('getAllPersonStatuses');
+                  const requestId = createHash('sha1').update('getAllPersonStatuses' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getAllPersonStatusesAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getAllPersonStatuses',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getBasicPersonDetailsFromUserNumber(Token: any, UserNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getBasicPersonDetailsFromUserNumber', Token, UserNumber);
+                  const requestId = createHash('sha1').update('getBasicPersonDetailsFromUserNumber' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getBasicPersonDetailsFromUserNumberAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getBasicPersonDetailsFromUserNumber',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getPeopleDetailsFromSurname(Token: any, Surname: any, FuzzySearch: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getPeopleDetailsFromSurname', Token, Surname, FuzzySearch);
+                  const requestId = createHash('sha1').update('getPeopleDetailsFromSurname' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getPeopleDetailsFromSurnameAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getPeopleDetailsFromSurname',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async getEmergencyContactDTO(token: any, userNumber: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('getEmergencyContactDTO', token, userNumber);
+                  const requestId = createHash('sha1').update('getEmergencyContactDTO' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['getEmergencyContactDTOAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'getEmergencyContactDTO',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async updateFedId(token: any, fedIdUserName: any, fedIdLoginPassword: any, objid: any, objdomid: any, expiryDate: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('updateFedId', token, fedIdUserName, fedIdLoginPassword, objid, objdomid, expiryDate);
+                  const requestId = createHash('sha1').update('updateFedId' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['updateFedIdAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'updateFedId',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+    public async updatePersonByDTOFromSource(token: any, person: any, updateSource: any) : Promise<any> {
+                  const argsObj = this.makeArgsObj('updatePersonByDTOFromSource', token, person, updateSource);
+                  const requestId = createHash('sha1').update('updatePersonByDTOFromSource' + JSON.stringify(argsObj)).digest('base64');
+
+                  const activeUowsRequest = this.activeUowsRequests.get(requestId);
+                  if (activeUowsRequest) {
+                    return activeUowsRequest;
+                  }
+
+                  const refinedResult = this.client['updatePersonByDTOFromSourceAsync'](argsObj).then((result: any) => {
+                      return result[0];
+                  }).catch((result: any) => {
+                      const response = result?.response;
+                      const exceptionMessage = response?.data?.match("<faultstring>(.*)</faultstring>")[1];
+                      logger.logWarn("A call to the UserOfficeWebService returned an exception: ", {
+                          exceptionMessage: exceptionMessage,
+                          method: 'updatePersonByDTOFromSource',
+                          serviceUrl: response?.config?.url,
+                          rawResponse: response?.data
+                      });
+
+                      throw (exceptionMessage) ? exceptionMessage : "Error while calling UserOfficeWebService";
+                  }).finally(() => {
+                    this.activeUowsRequests.delete(requestId);
+                  });
+                  this.activeUowsRequests.set(requestId, refinedResult);
+
+                  return refinedResult;
+              }
+
+
+
+         private makeArgsObj(functName: string, ...args: any[]) {
+              const argsObj : {[key: string]: any} = {};
+              const serviceDesc = this.wsdlDesc[Object.keys(this.wsdlDesc)[0]];
+              const collectionOfFunctions = serviceDesc[Object.keys(serviceDesc)[0]];
+              const argsDescr = collectionOfFunctions[functName];
+  
+              Object.keys(argsDescr.input).forEach((element: string, index: number) => {
+                  if (element !== 'targetNSAlias' && element !== 'targetNamespace') {
+                      const argName: string = element.replace('[]', '');
+                      argsObj[argName] = args[index];
+                  }
+              });
+              return argsObj;
+          }
+
+
+    }
+  

--- a/src/datasources/stfc/__mocks__/UOWSSoapInterface.ts
+++ b/src/datasources/stfc/__mocks__/UOWSSoapInterface.ts
@@ -1,4 +1,14 @@
 export default class UOWSSoapClient {
+  private static instance = new UOWSSoapClient();
+
+  static getInstance() {
+    return this.instance;
+  }
+
+  private UOWSSoapClient() {
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async getPersonDetailsFromSessionId(SessionId: any): Promise<any> {
     if (SessionId !== 'valid') {


### PR DESCRIPTION
## Description
Regenerates the UOWS client using the latest generator version. This includes changes which reduce calls made to the UOWS (from https://github.com/UserOfficeProject/user-office-lib/pull/131 and https://github.com/UserOfficeProject/user-office-lib/pull/134). The result of this should be much more reliable communication with the UOWS, reducing the problem of users being logged out when the UOWS receives too many requests. When testing locally, my setup has gone from reliably logging me out whenever I access the User Officer dashboard to always working on all pages I tested.

As part of this, Typescript was automatically updated to its latest version, because the `uows-client-generator` package now requires a later version of Typescript than the one previously used in this app. The ESlint plugins have been updated to match the new Typescript version.

The new version of TypeScript also spotted a problem with the SEP authorization check, which I fixed in 82879091a40698c8892e94a9ddbdae265f4367ab.

## Motivation and Context
The UOWS stops responding on time if it receives too many requests. The latest version of `uows-client-generator` mitigates the problem.

## How Has This Been Tested
By loading GraphQL-intensive frontend pages on my local setup.

## Fixes
Part of https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/580

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
