### PR TITLE
fix: grant reading users for access token

### DIFF
--- a/src/auth/UserAuthorization.ts
+++ b/src/auth/UserAuthorization.ts
@@ -90,7 +90,13 @@ export abstract class UserAuthorization {
     const isUserOfficer = this.isUserOfficer(agent);
     const isInstrumentScientist = this.isInstrumentScientist(agent);
     const isSEPMember = await this.isMemberOfSEP(agent);
-    if (isUserOfficer || isInstrumentScientist || isSEPMember) {
+    const isApiAccessToken = this.isApiToken(agent);
+    if (
+      isUserOfficer ||
+      isInstrumentScientist ||
+      isSEPMember ||
+      isApiAccessToken
+    ) {
       return ids;
     }
 


### PR DESCRIPTION
## Description

This query
```
query {
  proposals(filter: { instrumentId: 4 }) {
    proposals {
      proposer {
        firstname
      }
    }
  }
}
```

Will fail if requested with the API access token with reading privileges

I believe this change is related to https://github.com/UserOfficeProject/user-office-backend/issues/678 , so please any feedback from @martin-trajanovski is appreciated because you looked into similar issue with SEP.


