### PR TITLE
fix(pdf file upload): Hotfix for unlimited PDF page limit

### DIFF
--- a/src/models/questionTypes/FileUpload.ts
+++ b/src/models/questionTypes/FileUpload.ts
@@ -276,6 +276,14 @@ const hasAllowedPdfNumPages = async (
 
   const pageLimit = config.pdf_page_limit;
 
+  if (pageLimit == 0) {
+    logger.logInfo('Skipping PDF page check as limit is unlimited', {
+      ...errorContext,
+    });
+
+    return true;
+  }
+
   const readPdf = async () => {
     return createReader(path);
   };


### PR DESCRIPTION
## Description
This is a hotfix that treats 0 in the PDF file upload page limit as unlimited. I missed this logic out when I did this work, sorry.

As mentioned in https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/625, we can work around this for now by setting a different page limit.