### PR TITLE
refactor: import faker from fork UserOfficeProject/user-office-projec…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "yup": "^0.32.11"
       },
       "devDependencies": {
+        "@faker-js/faker": "^7.3.0",
         "@types/bcryptjs": "^2.4.2",
         "@types/clamscan": "^2.0.2",
         "@types/content-disposition": "^0.5.4",
@@ -60,7 +61,6 @@
         "@types/email-templates": "^8.0.4",
         "@types/express": "^4.17.13",
         "@types/express-jwt": "^6.0.4",
-        "@types/faker": "^5.5.8",
         "@types/jest": "^27.4.0",
         "@types/jsonwebtoken": "^8.5.5",
         "@types/luxon": "^2.3.0",
@@ -86,7 +86,6 @@
         "eslint-plugin-jest": "^25.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-unused-imports": "^2.0.0",
-        "faker": "5.5.3",
         "husky": "^4.3.8",
         "jest": "^27.4.5",
         "lint-staged": "^10.5.4",
@@ -795,6 +794,16 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.3.0.tgz",
+      "integrity": "sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@graphql-tools/delegate": {
@@ -1787,12 +1796,6 @@
       "dependencies": {
         "@types/express": "*"
       }
-    },
-    "node_modules/@types/faker": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.9.tgz",
-      "integrity": "sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==",
-      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -13304,6 +13307,12 @@
         }
       }
     },
+    "@faker-js/faker": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.3.0.tgz",
+      "integrity": "sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==",
+      "dev": true
+    },
     "@graphql-tools/delegate": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.5.1.tgz",
@@ -14163,12 +14172,6 @@
       "requires": {
         "@types/express": "*"
       }
-    },
-    "@types/faker": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.9.tgz",
-      "integrity": "sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==",
-      "dev": true
     },
     "@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
+    "@faker-js/faker": "^7.3.0",
     "@types/bcryptjs": "^2.4.2",
     "@types/clamscan": "^2.0.2",
     "@types/content-disposition": "^0.5.4",
@@ -90,7 +91,6 @@
     "@types/email-templates": "^8.0.4",
     "@types/express": "^4.17.13",
     "@types/express-jwt": "^6.0.4",
-    "@types/faker": "^5.5.8",
     "@types/jest": "^27.4.0",
     "@types/jsonwebtoken": "^8.5.5",
     "@types/luxon": "^2.3.0",
@@ -116,7 +116,6 @@
     "eslint-plugin-jest": "^25.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unused-imports": "^2.0.0",
-    "faker": "5.5.3",
     "husky": "^4.3.8",
     "jest": "^27.4.5",
     "lint-staged": "^10.5.4",

--- a/src/populate/dummy.ts
+++ b/src/populate/dummy.ts
@@ -1,11 +1,11 @@
-import * as faker from 'faker';
+import { faker } from '@faker-js/faker';
 
 export function word() {
   return faker.random.word().split(' ').join().split('-').join();
 }
 
 export function positiveNumber(max: number) {
-  return faker.random.number(max - 1) + 1;
+  return faker.datatype.number(max - 1) + 1;
 }
 
 export function title() {

--- a/src/populate/index.ts
+++ b/src/populate/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import 'dotenv/config';
 
-import faker from 'faker';
+import { faker } from '@faker-js/faker';
 import 'reflect-metadata';
 import '../config';
 import { container } from 'tsyringe';
@@ -76,8 +76,8 @@ const createUsers = async () => {
       faker.internet.userName(),
       '$2a$10$1svMW3/FwE5G1BpE7/CPW.aMyEymEBeWK4tSTtABbsoo/KaSQ.vwm',
       faker.name.firstName(),
-      faker.random.uuid(),
-      faker.random.uuid(),
+      faker.datatype.uuid(),
+      faker.datatype.uuid(),
       dummy.gender(),
       dummy.positiveNumber(20),
       faker.date.past(30),
@@ -154,7 +154,7 @@ const createCalls = async () => {
       endReview: faker.date.future(1),
       endSEPReview: faker.date.future(1),
       referenceNumberFormat: faker.random.words(8),
-      proposalSequence: faker.random.number({
+      proposalSequence: faker.datatype.number({
         min: 0,
         max: 100,
       }),
@@ -182,7 +182,7 @@ const createTemplates = async () => {
   for (const template of templates) {
     await execute(() => {
       return templateDataSource.createTopic({
-        sortOrder: faker.random.number({
+        sortOrder: faker.datatype.number({
           min: 0,
           max: 100,
         }),
@@ -214,7 +214,7 @@ const createTemplates = async () => {
         await templateDataSource.upsertQuestionTemplateRelations([
           {
             questionId: question.id,
-            sortOrder: faker.random.number({
+            sortOrder: faker.datatype.number({
               min: 0,
               max: 100,
             }),
@@ -307,7 +307,7 @@ const createReviews = async () => {
             ? TechnicalReviewStatus.FEASIBLE
             : TechnicalReviewStatus.UNFEASIBLE,
         timeAllocation: dummy.positiveNumber(10),
-        submitted: faker.random.boolean(),
+        submitted: faker.datatype.boolean(),
         reviewerId: 1,
         files: '[]',
       },


### PR DESCRIPTION
closes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/312
## Description

<!--- Describe your changes in detail -->
Imported faker from a fork: https://github.com/faker-js/faker
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Faker has been corrupted and abandoned
## How Has This Been Tested
Ran e2e tests locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->
fixes: https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/312
## Changes

<!--- What types of changes does your code introduce? In what place? -->
Imported faker 
uninstalled old faker packages
## Depends on
https://github.com/UserOfficeProject/user-office-frontend/pull/962
<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
