### PR TITLE
fix: Hotfix for STFC instrument assignment

### DIFF
--- a/src/auth/StfcUserAuthorization.spec.ts
+++ b/src/auth/StfcUserAuthorization.spec.ts
@@ -26,6 +26,11 @@ const mockAssignScientistToInstruments = jest.spyOn(
   'assignScientistToInstruments'
 );
 
+const mockGetRequiredInstrumentForRole = jest.spyOn(
+  userAuthorization,
+  'getRequiredInstrumentForRole'
+);
+
 const instruments = [
   new Instrument(0, 'ISIS', '', '', 0),
   new Instrument(1, 'LSF', '', '', 0),
@@ -48,6 +53,7 @@ beforeAll(() => {
 beforeEach(() => {
   mockAssignScientistToInstruments.mockClear();
   mockRemoveScientistFromInstruments.mockClear();
+  mockGetRequiredInstrumentForRole.mockClear();
 });
 
 test('When an invalid external token is supplied, no user is found', async () => {
@@ -63,6 +69,32 @@ test('When a valid external token is supplied, valid user is returned', async ()
 
   expect(result?.id).toBe(dummyUser.id);
   expect(result?.email).toBe(dummyUser.email);
+});
+
+test('When getting instruments for roles, duplicate roles are filtered out before', async () => {
+  await userAuthorization.externalTokenLogin('valid');
+
+  // Duplicate 'User Officer' and 'ISIS Instrument Scientist' roles removed
+  expect(mockGetRequiredInstrumentForRole).toBeCalledWith([
+    {
+      name: 'ISIS Instrument Scientist',
+    },
+    {
+      name: 'ISIS Administrator',
+    },
+    {
+      name: 'Developer',
+    },
+    {
+      name: 'Admin',
+    },
+    {
+      name: 'User Officer',
+    },
+    {
+      name: 'User',
+    },
+  ]);
 });
 
 // getInstrumentsToAdd

--- a/src/auth/StfcUserAuthorization.ts
+++ b/src/auth/StfcUserAuthorization.ts
@@ -210,7 +210,7 @@ export class StfcUserAuthorization extends UserAuthorization {
       // The UOWS sometimes returns duplicate roles. We remove them here
       const uniqueRoles = stfcRoles.filter(
         (role, index) =>
-          stfcRoles.findIndex((r) => r.name == role.name) !== index
+          stfcRoles.findIndex((r) => r.name == role.name) === index
       );
       const requiredInstruments =
         this.getRequiredInstrumentForRole(uniqueRoles);


### PR DESCRIPTION
This fixes instrment scientists (and others) not being assigned to instruments.

We were filtering out all of the non duplicate roles, instead of the inverse. On dev and for me at least, the "User Officer" role was the only duplicate, which is probably why we didn't notice.

Part of UserOfficeProject/user-office-project-issue-tracker#628