### PR TITLE
fix: Fix STFC email search

### DIFF
--- a/src/datasources/stfc/StfcUserDataSource.spec.ts
+++ b/src/datasources/stfc/StfcUserDataSource.spec.ts
@@ -1,61 +1,123 @@
 import { Role, Roles } from '../../models/Role';
 import { dummyUser } from '../mockups/UserDataSource';
 import { StfcUserDataSource } from './StfcUserDataSource';
+import UOWSSoapClient from './UOWSSoapInterface';
 
 jest.mock('./UOWSSoapInterface');
 jest.mock('../postgres/UserDataSource.ts');
 jest.mock('../../utils/LRUCache');
 
-const dummyUserNumber = 12345;
+describe('Role tests', () => {
+  const dummyUserNumber = 12345;
 
-beforeAll(() => {
-  const mockGetRoles = jest.spyOn(StfcUserDataSource.prototype, 'getRoles');
-  mockGetRoles.mockImplementation(() =>
-    Promise.resolve([
-      new Role(1, Roles.USER, 'User'),
-      new Role(2, Roles.USER_OFFICER, 'User Officer'),
-      new Role(3, Roles.INSTRUMENT_SCIENTIST, 'Instrument Scientist'),
-    ])
-  );
-  const mockEnsureDummyUserExists = jest.spyOn(
-    StfcUserDataSource.prototype,
-    'ensureDummyUserExists'
-  );
-  mockEnsureDummyUserExists.mockImplementation((userId: number) => {
-    const user = dummyUser;
-    user.id = userId;
+  beforeAll(() => {
+    const mockGetRoles = jest.spyOn(StfcUserDataSource.prototype, 'getRoles');
+    mockGetRoles.mockImplementation(() =>
+      Promise.resolve([
+        new Role(1, Roles.USER, 'User'),
+        new Role(2, Roles.USER_OFFICER, 'User Officer'),
+        new Role(3, Roles.INSTRUMENT_SCIENTIST, 'Instrument Scientist'),
+      ])
+    );
 
-    return Promise.resolve(user);
+    const mockEnsureDummyUserExists = jest.spyOn(
+      StfcUserDataSource.prototype,
+      'ensureDummyUserExists'
+    );
+
+    mockEnsureDummyUserExists.mockImplementation((userId: number) => {
+      const user = dummyUser;
+      user.id = userId;
+
+      return Promise.resolve(user);
+    });
+  });
+
+  test('When getting roles for a user, the User role is the first role in the list', async () => {
+    const userdataSource = new StfcUserDataSource();
+    const roles = await userdataSource.getUserRoles(dummyUserNumber);
+
+    return expect(roles[0]).toEqual(
+      expect.objectContaining(new Role(expect.any(Number), Roles.USER, 'User'))
+    );
+  });
+
+  test('When getting roles for a user, STFC roles are translated into ESS roles', async () => {
+    const userdataSource = new StfcUserDataSource();
+
+    return expect(
+      userdataSource.getUserRoles(dummyUserNumber)
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        new Role(1, Roles.USER, 'User'),
+        new Role(2, Roles.USER_OFFICER, 'User Officer'),
+        new Role(3, Roles.INSTRUMENT_SCIENTIST, 'Instrument Scientist'),
+      ])
+    );
+  });
+
+  test('When getting roles for a user, no roles are granted if role definitions do not exist', async () => {
+    const userdataSource = new StfcUserDataSource();
+    const mockGetRoles = jest.spyOn(userdataSource, 'getRoles');
+    mockGetRoles.mockImplementation(() => Promise.resolve([]));
+
+    const roles = await userdataSource.getUserRoles(dummyUserNumber);
+
+    return expect(roles).toHaveLength(0);
   });
 });
 
-test('When getting roles for a user, the User role is the first role in the list', async () => {
+describe('Email search tests', () => {
   const userdataSource = new StfcUserDataSource();
-  const roles = await userdataSource.getUserRoles(dummyUserNumber);
 
-  return expect(roles[0]).toEqual(
-    expect.objectContaining(new Role(expect.any(Number), Roles.USER, 'User'))
+  const uowsClient = UOWSSoapClient.getInstance();
+
+  const mockGetSearchableBasicPersonDetailsFromEmail = jest.spyOn(
+    uowsClient,
+    'getSearchableBasicPersonDetailsFromEmail'
   );
-});
 
-test('When getting roles for a user, STFC roles are translated into ESS roles', async () => {
-  const userdataSource = new StfcUserDataSource();
-
-  return expect(userdataSource.getUserRoles(dummyUserNumber)).resolves.toEqual(
-    expect.arrayContaining([
-      new Role(1, Roles.USER, 'User'),
-      new Role(2, Roles.USER_OFFICER, 'User Officer'),
-      new Role(3, Roles.INSTRUMENT_SCIENTIST, 'Instrument Scientist'),
-    ])
+  const mockGetBasicPersonDetailsFromEmail = jest.spyOn(
+    uowsClient,
+    'getBasicPersonDetailsFromEmail'
   );
-});
 
-test('When getting roles for a user, no roles are granted if role definitions do not exist', async () => {
-  const userdataSource = new StfcUserDataSource();
-  const mockGetRoles = jest.spyOn(userdataSource, 'getRoles');
-  mockGetRoles.mockImplementation(() => Promise.resolve([]));
+  const mockEnsureDummyUserExists = jest.spyOn(
+    userdataSource,
+    'ensureDummyUserExists'
+  );
 
-  const roles = await userdataSource.getUserRoles(dummyUserNumber);
+  beforeEach(() => {
+    mockGetSearchableBasicPersonDetailsFromEmail.mockClear();
+    mockGetBasicPersonDetailsFromEmail.mockClear();
+    mockEnsureDummyUserExists.mockClear();
+  });
 
-  return expect(roles).toHaveLength(0);
+  test('When getting basic user details, the basic user is created and returned', async () => {
+    const result = await userdataSource.getBasicUserDetailsByEmail('valid');
+
+    expect(mockGetBasicPersonDetailsFromEmail).toBeCalledTimes(0);
+    expect(mockGetSearchableBasicPersonDetailsFromEmail).toBeCalled();
+    expect(mockEnsureDummyUserExists).toBeCalled();
+
+    expect(result).toHaveProperty('id', 12345);
+  });
+
+  test('When getting non-basic user details, the non-basic user is created and returned', async () => {
+    const result = await userdataSource.getByEmail('valid');
+
+    expect(mockGetBasicPersonDetailsFromEmail).toBeCalled();
+    expect(mockGetSearchableBasicPersonDetailsFromEmail).toBeCalledTimes(0);
+    expect(mockEnsureDummyUserExists).toBeCalled();
+
+    expect(result).toHaveProperty('id', 12345);
+  });
+
+  test('When a user is not found by the UOWS, a dummy user is not created', async () => {
+    const result = await userdataSource.getByEmail('invalid');
+
+    expect(mockEnsureDummyUserExists).toBeCalledTimes(0);
+
+    expect(result).toBeNull();
+  });
 });

--- a/src/datasources/stfc/StfcUserDataSource.spec.ts
+++ b/src/datasources/stfc/StfcUserDataSource.spec.ts
@@ -97,8 +97,8 @@ describe('Email search tests', () => {
     const result = await userdataSource.getBasicUserDetailsByEmail('valid');
 
     expect(mockGetBasicPersonDetailsFromEmail).toBeCalledTimes(0);
-    expect(mockGetSearchableBasicPersonDetailsFromEmail).toBeCalled();
-    expect(mockEnsureDummyUserExists).toBeCalled();
+    expect(mockGetSearchableBasicPersonDetailsFromEmail).toBeCalledTimes(1);
+    expect(mockEnsureDummyUserExists).toBeCalledTimes(1);
 
     expect(result).toHaveProperty('id', 12345);
   });
@@ -106,9 +106,9 @@ describe('Email search tests', () => {
   test('When getting non-basic user details, the non-basic user is created and returned', async () => {
     const result = await userdataSource.getByEmail('valid');
 
-    expect(mockGetBasicPersonDetailsFromEmail).toBeCalled();
+    expect(mockGetBasicPersonDetailsFromEmail).toBeCalledTimes(1);
     expect(mockGetSearchableBasicPersonDetailsFromEmail).toBeCalledTimes(0);
-    expect(mockEnsureDummyUserExists).toBeCalled();
+    expect(mockEnsureDummyUserExists).toBeCalledTimes(1);
 
     expect(result).toHaveProperty('id', 12345);
   });

--- a/src/datasources/stfc/StfcUserDataSource.spec.ts
+++ b/src/datasources/stfc/StfcUserDataSource.spec.ts
@@ -120,4 +120,21 @@ describe('Email search tests', () => {
 
     expect(result).toBeNull();
   });
+
+  test('When an invalid token is provided, a dummy user is not created', async () => {
+    mockGetBasicPersonDetailsFromEmail.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      (Token: any, Email: any) => {
+        return Promise.resolve({
+          return: null,
+        });
+      }
+    );
+
+    const result = await userdataSource.getByEmail('valid');
+
+    expect(mockEnsureDummyUserExists).toBeCalledTimes(0);
+
+    expect(result).toBeNull();
+  });
 });

--- a/src/datasources/stfc/StfcUserDataSource.ts
+++ b/src/datasources/stfc/StfcUserDataSource.ts
@@ -183,8 +183,8 @@ export class StfcUserDataSource implements UserDataSource {
 
     const uowsRequest = searchableOnly
       ? client.getSearchableBasicPersonDetailsFromEmail(token, email)
-      : client.getBasicPersonDetailsFromEmail;
-    const stfcUser: StfcBasicPersonDetails | null = (await uowsRequest)?.return;
+      : client.getBasicPersonDetailsFromEmail(token, email);
+    const stfcUser: StfcBasicPersonDetails | null = (await uowsRequest).return;
 
     if (!stfcUser) {
       return null;

--- a/src/datasources/stfc/StfcUserDataSource.ts
+++ b/src/datasources/stfc/StfcUserDataSource.ts
@@ -184,7 +184,7 @@ export class StfcUserDataSource implements UserDataSource {
     const uowsRequest = searchableOnly
       ? client.getSearchableBasicPersonDetailsFromEmail(token, email)
       : client.getBasicPersonDetailsFromEmail;
-    const stfcUser: StfcBasicPersonDetails | null = (await uowsRequest).return;
+    const stfcUser: StfcBasicPersonDetails | null = (await uowsRequest)?.return;
 
     if (!stfcUser) {
       return null;

--- a/src/datasources/stfc/__mocks__/UOWSSoapInterface.ts
+++ b/src/datasources/stfc/__mocks__/UOWSSoapInterface.ts
@@ -23,6 +23,42 @@ export default class UOWSSoapClient {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async getSearchableBasicPersonDetailsFromEmail(
+    Token: any,
+    Email: any
+  ): Promise<any> {
+    if (Email === 'valid') {
+      return {
+        return: {
+          userNumber: '12345',
+        },
+      };
+    } else {
+      return {
+        return: null,
+      };
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async getBasicPersonDetailsFromEmail(
+    Token: any,
+    Email: any
+  ): Promise<any> {
+    if (Email === 'valid') {
+      return {
+        return: {
+          userNumber: '12345',
+        },
+      };
+    } else {
+      return {
+        return: null,
+      };
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async getRolesForUser(): Promise<any> {
     return {
       return: [


### PR DESCRIPTION
## Description
(View without whitespace changes)

This is a hotfix that fixes an error when searching for a user to add as PI or Co-I, when the UOWS returns no results.

Refs UserOfficeProject/user-office-project-issue-tracker#632

## How Has This Been Tested

- Tested that a frontend error displays rather than the backend throwing an error
- Fix aligns with the backend error thrown



