### PR TITLE
fix: Fix STFC email search

### DIFF
--- a/src/auth/StfcUserAuthorization.ts
+++ b/src/auth/StfcUserAuthorization.ts
@@ -164,7 +164,7 @@ export class StfcUserAuthorization extends UserAuthorization {
   async externalTokenLogin(token: string): Promise<User | null> {
     const stfcUser: StfcBasicPersonDetails | null = await client
       .getPersonDetailsFromSessionId(token)
-      .then((rawStfcUser) => rawStfcUser.return)
+      .then((rawStfcUser) => rawStfcUser?.return)
       .catch((error) => {
         const rethrowMessage =
           'Failed to fetch user details for STFC external authentication';
@@ -243,7 +243,7 @@ export class StfcUserAuthorization extends UserAuthorization {
       return cachedValidity;
     }
 
-    const isValid: boolean = (await client.isTokenValid(token)).return;
+    const isValid: boolean = (await client.isTokenValid(token))?.return;
     // Only cache valid tokens to avoid locking out users for a long time
     if (isValid) {
       this.uowsTokenCache.put(token, true);

--- a/src/datasources/stfc/StfcUserDataSource.spec.ts
+++ b/src/datasources/stfc/StfcUserDataSource.spec.ts
@@ -125,9 +125,7 @@ describe('Email search tests', () => {
     mockGetBasicPersonDetailsFromEmail.mockImplementation(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       (Token: any, Email: any) => {
-        return Promise.resolve({
-          return: null,
-        });
+        return Promise.resolve(null);
       }
     );
 

--- a/src/datasources/stfc/StfcUserDataSource.ts
+++ b/src/datasources/stfc/StfcUserDataSource.ts
@@ -184,7 +184,7 @@ export class StfcUserDataSource implements UserDataSource {
     const uowsRequest = searchableOnly
       ? client.getSearchableBasicPersonDetailsFromEmail(token, email)
       : client.getBasicPersonDetailsFromEmail(token, email);
-    const stfcUser: StfcBasicPersonDetails | null = (await uowsRequest).return;
+    const stfcUser: StfcBasicPersonDetails | null = (await uowsRequest)?.return;
 
     if (!stfcUser) {
       return null;

--- a/src/datasources/stfc/StfcUserDataSource.ts
+++ b/src/datasources/stfc/StfcUserDataSource.ts
@@ -154,7 +154,7 @@ export class StfcUserDataSource implements UserDataSource {
           )
         : client.getBasicPeopleDetailsFromUserNumbers(token, userNumbers);
       const usersFromUows: StfcBasicPersonDetails[] | null = (await uowsRequest)
-        .return;
+        ?.return;
 
       if (usersFromUows) {
         this.ensureDummyUsersExist(

--- a/src/datasources/stfc/__mocks__/UOWSSoapInterface.ts
+++ b/src/datasources/stfc/__mocks__/UOWSSoapInterface.ts
@@ -34,9 +34,7 @@ export default class UOWSSoapClient {
         },
       };
     } else {
-      return {
-        return: null,
-      };
+      return null;
     }
   }
 
@@ -52,9 +50,7 @@ export default class UOWSSoapClient {
         },
       };
     } else {
-      return {
-        return: null,
-      };
+      return null;
     }
   }
 


### PR DESCRIPTION
Second attempt at fixing the STFC email search, since I missed out the optional chaining last time 🙃

The UOWS returns null when users aren't found which is why it's necessary. I've amended the tests to reflect that, and also added a few other elvis operators to avoid thrown errors in other places.

I've double checked it this time 😅