### PR TITLE
Swap 2732 add add questionnaire queries

### DIFF
--- a/src/datasources/ProposalDataSource.ts
+++ b/src/datasources/ProposalDataSource.ts
@@ -94,6 +94,6 @@ export interface ProposalDataSource {
   updateProposalBookingScheduledEvent(
     eventMessage: ScheduledEventCore
   ): Promise<void>;
-
   getRelatedUsersOnProposals(id: number): Promise<number[]>;
+  getProposalById(proposalId: string): Promise<Proposal | null>;
 }

--- a/src/datasources/mockups/ProposalDataSource.ts
+++ b/src/datasources/mockups/ProposalDataSource.ts
@@ -382,4 +382,8 @@ export class ProposalDataSourceMock implements ProposalDataSource {
   async getRelatedUsersOnProposals(id: number): Promise<number[]> {
     return [basicDummyUser.id];
   }
+
+  async getProposalById(proposalId: string): Promise<Proposal | null> {
+    return dummyProposal.proposalId === proposalId ? dummyProposal : null;
+  }
 }

--- a/src/datasources/postgres/ProposalDataSource.ts
+++ b/src/datasources/postgres/ProposalDataSource.ts
@@ -961,4 +961,15 @@ export default class PostgresProposalDataSource implements ProposalDataSource {
 
     return relatedUsers;
   }
+
+  async getProposalById(proposalId: string): Promise<Proposal | null> {
+    return database
+      .select()
+      .from('proposals')
+      .where('proposal_id', proposalId)
+      .first()
+      .then((proposal: ProposalRecord) => {
+        return proposal ? createProposalObject(proposal) : null;
+      });
+  }
 }

--- a/src/queries/ProposalQueries.spec.ts
+++ b/src/queries/ProposalQueries.spec.ts
@@ -11,7 +11,7 @@ import {
   dummyUserOfficerWithRole,
   dummyUserWithRole,
 } from '../datasources/mockups/UserDataSource';
-import { ProposalPublicStatus } from '../models/Proposal';
+import { Proposal, ProposalPublicStatus } from '../models/Proposal';
 import { omit } from '../utils/helperFunctions';
 import ProposalQueries from './ProposalQueries';
 
@@ -71,4 +71,22 @@ test('User should see the right status for submitted proposal', async () => {
   return expect(
     proposalQueries.getPublicStatus(dummyUserWithRole, 2)
   ).resolves.toBe(ProposalPublicStatus.accepted);
+});
+
+test('User on proposal should get the proposal', async () => {
+  return expect(
+    proposalQueries.getProposalById(dummyUserWithRole, 'shortCode')
+  ).resolves.toBeInstanceOf(Proposal);
+});
+
+test('User not on proposal should not get the proposal', async () => {
+  return expect(
+    proposalQueries.getProposalById(dummyUserNotOnProposalWithRole, 'shortCode')
+  ).resolves.not.toBeInstanceOf(Proposal);
+});
+
+test('User officer should get the proposal', async () => {
+  return expect(
+    proposalQueries.getProposalById(dummyUserOfficerWithRole, 'shortCode')
+  ).resolves.toBeInstanceOf(Proposal);
 });

--- a/src/queries/ProposalQueries.ts
+++ b/src/queries/ProposalQueries.ts
@@ -185,4 +185,15 @@ export default class ProposalQueries {
       filter
     );
   }
+
+  @Authorized()
+  async getProposalById(agent: UserWithRole | null, proposalId: string) {
+    const proposal = await this.dataSource.getProposalById(proposalId);
+
+    if ((await this.hasReadRights(agent, proposal)) === true) {
+      return proposal;
+    } else {
+      return null;
+    }
+  }
 }

--- a/src/queries/TemplateQueries.spec.ts
+++ b/src/queries/TemplateQueries.spec.ts
@@ -66,3 +66,12 @@ test('User officer should get a list of templates', async () => {
   expect(templates.length).toBeGreaterThan(0);
   expect(templates[0].isArchived).toEqual(false);
 });
+
+test('User officer should be able to get question by natural key', async () => {
+  const question = await templateQueries.getQuestionByNaturalKey(
+    dummyUserWithRole,
+    'proposal_basis'
+  );
+
+  return expect(question).not.toBe(null);
+});

--- a/src/queries/TemplateQueries.ts
+++ b/src/queries/TemplateQueries.ts
@@ -71,4 +71,9 @@ export default class TemplateQueries {
   ) {
     return this.dataSource.getActiveTemplateId(templateCategoryId);
   }
+
+  @Authorized()
+  async getQuestionByNaturalKey(user: UserWithRole | null, naturalKey: string) {
+    return this.dataSource.getQuestionByNaturalKey(naturalKey);
+  }
 }

--- a/src/resolvers/queries/ProposalByIdQuery.ts
+++ b/src/resolvers/queries/ProposalByIdQuery.ts
@@ -1,0 +1,14 @@
+import { Arg, Ctx, Query, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { Proposal } from '../types/Proposal';
+@Resolver()
+export class ProposalByIdQuery {
+  @Query(() => Proposal, { nullable: true })
+  async proposalById(
+    @Arg('proposalId', () => String) proposalId: string,
+    @Ctx() context: ResolverContext
+  ): Promise<Proposal | null> {
+    return context.queries.proposal.getProposalById(context.user, proposalId);
+  }
+}

--- a/src/resolvers/queries/QuestionByNaturalKeyQuery.ts
+++ b/src/resolvers/queries/QuestionByNaturalKeyQuery.ts
@@ -1,0 +1,19 @@
+import { Arg, Ctx, Query, Resolver } from 'type-graphql';
+
+import { ResolverContext } from '../../context';
+import { Question } from '../types/Question';
+
+@Resolver()
+export class QuestionByNaturalKeyQuery {
+  @Query(() => [Question])
+  questions(
+    @Arg('naturalKey', () => String)
+    naturalKey: string,
+    @Ctx() context: ResolverContext
+  ) {
+    return context.queries.template.getQuestionByNaturalKey(
+      context.user,
+      naturalKey
+    );
+  }
+}


### PR DESCRIPTION
## Description

This PR adds 2 useful queries for 3rd party integration
- proposalById
- questionByNaturalKey

## Motivation and Context

This PR aims to make GraphQL endpoints more consistent and more friendly for 3rd party integration

## How Has This Been Tested

- [x] Manual tests
- [x] E2E tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-2732

## Changes

This PR changes endpoints
- proposalById
- questionByNaturalKey

## Depends on
N/A



