### PR TITLE
feat: add logging on error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "apollo-graphql": "^0.9.5",
         "apollo-server-core": "^3.10.1",
         "apollo-server-express": "^3.6.3",
+        "apollo-server-plugin-base": "^3.6.2",
         "await-to-js": "^2.1.1",
         "axios": "^0.26.0",
         "bcryptjs": "^2.4.3",
@@ -2981,17 +2982,6 @@
         "@apollo/protobufjs": "1.2.4"
       }
     },
-    "node_modules/apollo-server-caching": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
-      "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/apollo-server-core": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.1.tgz",
@@ -3152,37 +3142,6 @@
         "graphql": "^15.3.0 || ^16.0.0"
       }
     },
-    "node_modules/apollo-server-core/node_modules/apollo-server-plugin-base": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.2.tgz",
-      "integrity": "sha512-erWXjLOO1u7fxQkbxJ2cwSO7p0tYzNied91I1SJ9tikXZ/2eZUyDyvrpI+4g70kOdEi+AmJ5Fo8ahEXKJ75zdg==",
-      "dependencies": {
-        "apollo-server-types": "^3.6.2"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/apollo-server-types": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.2.tgz",
-      "integrity": "sha512-9Z54S7NB+qW1VV+kmiqwU2Q6jxWfX89HlSGCGOo3zrkrperh85LrzABgN9S92+qyeHYd72noMDg2aI039sF3dg==",
-      "dependencies": {
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0",
-        "apollo-reporting-protobuf": "^3.3.2",
-        "apollo-server-env": "^4.2.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
     "node_modules/apollo-server-core/node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -3227,13 +3186,28 @@
         "graphql": "^15.3.0 || ^16.0.0"
       }
     },
-    "node_modules/apollo-server-types": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.5.1.tgz",
-      "integrity": "sha512-zG7xLl4mmHuZMAYOfjWKHY/IC/GgIkJ3HnYuR7FRrnPpRA9Yt5Kf1M1rjm1Esuqzpb/dt8pM7cX40QaIQObCYQ==",
+    "node_modules/apollo-server-plugin-base": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.2.tgz",
+      "integrity": "sha512-erWXjLOO1u7fxQkbxJ2cwSO7p0tYzNied91I1SJ9tikXZ/2eZUyDyvrpI+4g70kOdEi+AmJ5Fo8ahEXKJ75zdg==",
       "dependencies": {
-        "apollo-reporting-protobuf": "^3.3.0",
-        "apollo-server-caching": "^3.3.0",
+        "apollo-server-types": "^3.6.2"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-types": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.2.tgz",
+      "integrity": "sha512-9Z54S7NB+qW1VV+kmiqwU2Q6jxWfX89HlSGCGOo3zrkrperh85LrzABgN9S92+qyeHYd72noMDg2aI039sF3dg==",
+      "dependencies": {
+        "@apollo/utils.keyvaluecache": "^1.0.1",
+        "@apollo/utils.logger": "^1.0.0",
+        "apollo-reporting-protobuf": "^3.3.2",
         "apollo-server-env": "^4.2.1"
       },
       "engines": {
@@ -15046,14 +15020,6 @@
         "@apollo/protobufjs": "1.2.4"
       }
     },
-    "apollo-server-caching": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
-      "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
     "apollo-server-core": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.1.tgz",
@@ -15163,25 +15129,6 @@
           "integrity": "sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==",
           "requires": {}
         },
-        "apollo-server-plugin-base": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.2.tgz",
-          "integrity": "sha512-erWXjLOO1u7fxQkbxJ2cwSO7p0tYzNied91I1SJ9tikXZ/2eZUyDyvrpI+4g70kOdEi+AmJ5Fo8ahEXKJ75zdg==",
-          "requires": {
-            "apollo-server-types": "^3.6.2"
-          }
-        },
-        "apollo-server-types": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.2.tgz",
-          "integrity": "sha512-9Z54S7NB+qW1VV+kmiqwU2Q6jxWfX89HlSGCGOo3zrkrperh85LrzABgN9S92+qyeHYd72noMDg2aI039sF3dg==",
-          "requires": {
-            "@apollo/utils.keyvaluecache": "^1.0.1",
-            "@apollo/utils.logger": "^1.0.0",
-            "apollo-reporting-protobuf": "^3.3.2",
-            "apollo-server-env": "^4.2.1"
-          }
-        },
         "whatwg-mimetype": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -15215,13 +15162,22 @@
         "parseurl": "^1.3.3"
       }
     },
-    "apollo-server-types": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.5.1.tgz",
-      "integrity": "sha512-zG7xLl4mmHuZMAYOfjWKHY/IC/GgIkJ3HnYuR7FRrnPpRA9Yt5Kf1M1rjm1Esuqzpb/dt8pM7cX40QaIQObCYQ==",
+    "apollo-server-plugin-base": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.2.tgz",
+      "integrity": "sha512-erWXjLOO1u7fxQkbxJ2cwSO7p0tYzNied91I1SJ9tikXZ/2eZUyDyvrpI+4g70kOdEi+AmJ5Fo8ahEXKJ75zdg==",
       "requires": {
-        "apollo-reporting-protobuf": "^3.3.0",
-        "apollo-server-caching": "^3.3.0",
+        "apollo-server-types": "^3.6.2"
+      }
+    },
+    "apollo-server-types": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.2.tgz",
+      "integrity": "sha512-9Z54S7NB+qW1VV+kmiqwU2Q6jxWfX89HlSGCGOo3zrkrperh85LrzABgN9S92+qyeHYd72noMDg2aI039sF3dg==",
+      "requires": {
+        "@apollo/utils.keyvaluecache": "^1.0.1",
+        "@apollo/utils.logger": "^1.0.0",
+        "apollo-reporting-protobuf": "^3.3.2",
         "apollo-server-env": "^4.2.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "apollo-graphql": "^0.9.5",
     "apollo-server-core": "^3.10.1",
     "apollo-server-express": "^3.6.3",
+    "apollo-server-plugin-base": "^3.6.2",
     "await-to-js": "^2.1.1",
     "axios": "^0.26.0",
     "bcryptjs": "^2.4.3",

--- a/src/middlewares/graphql.ts
+++ b/src/middlewares/graphql.ts
@@ -1,3 +1,4 @@
+import { logger } from '@user-office-software/duo-logger';
 import {
   ApolloServerPluginInlineTraceDisabled,
   ApolloServerPluginLandingPageDisabled,
@@ -5,6 +6,10 @@ import {
   ApolloServerPluginUsageReporting,
 } from 'apollo-server-core';
 import { ApolloServer } from 'apollo-server-express';
+import type {
+  ApolloServerPlugin,
+  BaseContext,
+} from 'apollo-server-plugin-base';
 import { Express } from 'express';
 import { GraphQLError } from 'graphql';
 import { container } from 'tsyringe';
@@ -42,6 +47,18 @@ const apolloServer = async (app: Express) => {
     }
   );
 
+  const errorLoggingPlugin: ApolloServerPlugin<BaseContext> = {
+    async requestDidStart() {
+      return {
+        async willSendResponse({ response: { errors } }) {
+          if (errors) {
+            logger.logInfo('GraphQL response contained error(s)', { errors });
+          }
+        },
+      };
+    },
+  };
+
   const plugins = [
     ApolloServerPluginInlineTraceDisabled(),
     // Explicitly disable playground in prod
@@ -50,6 +67,7 @@ const apolloServer = async (app: Express) => {
       : ApolloServerPluginLandingPageGraphQLPlayground({
           settings: { 'schema.polling.enable': false },
         }),
+    errorLoggingPlugin,
   ];
   /*
   Only use the usage reporting plugin if apollo studio connection settings are

--- a/src/middlewares/graphql.ts
+++ b/src/middlewares/graphql.ts
@@ -50,10 +50,10 @@ const apolloServer = async (app: Express) => {
   const errorLoggingPlugin: ApolloServerPlugin<BaseContext> = {
     async requestDidStart() {
       return {
-        async willSendResponse({ response: { errors } }) {
-          if (errors) {
-            logger.logInfo('GraphQL response contained error(s)', { errors });
-          }
+        async didEncounterErrors({ errors }) {
+          logger.logInfo('GraphQL response contained error(s)', {
+            errors,
+          });
         },
       };
     },


### PR DESCRIPTION
Refs https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/645
Refs https://github.com/UserOfficeProject/user-office-project-issue-tracker/issues/18

## Description

Adds an error logging plugin which puts any GraphQL errors to the logging framework. Using `info` as an error over GraphQL might not actually be an error.

## Motivation and Context

Currently looking at load testing our services and they don't let the server know when they've failed, if there's been failed requests. In addition, this means we're not relying on the client providing information to the server.

## How Has This Been Tested

Running the application locally and E2E using https://github.com/UserOfficeProject/user-office-frontend/pull/993.

## Fixes

N/A - just part of other issues

## Changes

Creates a simple plugin and adds it to the `src/middlewares/graphql.ts`.

## Depends on

N/A

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [x] All relevant doc has been updated
