### PR TITLE
Use flat directory structure for emails

### DIFF
--- a/src/eventHandlers/MailService/SMTPMailService.ts
+++ b/src/eventHandlers/MailService/SMTPMailService.ts
@@ -47,6 +47,12 @@ export class SMTPMailService extends MailService {
           relativeTo: path.resolve(process.env.EMAIL_TEMPLATE_PATH || ''),
         },
       },
+      getPath: (type, template) => {
+        return path.join(
+          process.env.EMAIL_TEMPLATE_PATH || '',
+          `${template}.${type}`
+        );
+      },
     });
   }
 
@@ -65,18 +71,17 @@ export class SMTPMailService extends MailService {
       sendMailResults.id = 'test';
     }
 
-    options.content.template_id = path.join(
+    const template = path.join(
       process.env.EMAIL_TEMPLATE_PATH || '',
-      options.content.template_id
+      `${options.content.template_id}.html.pug`
     );
-    const template = path.join(options.content.template_id, 'html.pug');
 
     if (
       !(await (this._email as any).templateExists(template)) &&
       process.env.NODE_ENV !== 'test'
     ) {
       logger.logError('Template does not exist', {
-        templateId: options.content.template_id,
+        templateId: template,
       });
 
       return { results: sendMailResults };

--- a/src/eventHandlers/MailService/SMTPMailService.ts
+++ b/src/eventHandlers/MailService/SMTPMailService.ts
@@ -47,13 +47,15 @@ export class SMTPMailService extends MailService {
           relativeTo: path.resolve(process.env.EMAIL_TEMPLATE_PATH || ''),
         },
       },
-      getPath: (type, template) => {
-        return path.join(
-          process.env.EMAIL_TEMPLATE_PATH || '',
-          `${template}.${type}`
-        );
-      },
+      getPath: this.getEmailTemplatePath,
     });
+  }
+
+  private getEmailTemplatePath(type: string, template: string): string {
+    return path.join(
+      process.env.EMAIL_TEMPLATE_PATH || '',
+      `${template}.${type}`
+    );
   }
 
   async sendMail(options: EmailSettings): Promise<{
@@ -71,10 +73,8 @@ export class SMTPMailService extends MailService {
       sendMailResults.id = 'test';
     }
 
-    const template = path.join(
-      process.env.EMAIL_TEMPLATE_PATH || '',
-      `${options.content.template_id}.html.pug`
-    );
+    const template =
+      this.getEmailTemplatePath('html', options.content.template_id) + '.pug';
 
     if (
       !(await (this._email as any).templateExists(template)) &&


### PR DESCRIPTION
## Description
The backend now expects a flat directory structure in the emails directory, where emails are stored in a format like
`emails/<email name>.<file type>.pug`.

## Motivation and Context

This allows them to be mounted in using a Kubernetes ConfigMap, which doesn't support nested directories.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes
Part of https://github.com/isisbusapps/docker-orchestration/issues/148

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
